### PR TITLE
Updated FB_MotionVirtualFrame FB from latest library by copying it in…

### DIFF
--- a/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleVY.xti
+++ b/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleVY.xti
@@ -1326,7 +1326,7 @@ External Setpoint Generation:
 		<AxisPara>
 			<Dynamic Acceleration="2" Deceleration="2"/>
 			<Velo RefSearch="0.5" RefSync="0.5" SlowManual="0.25" FastManual="0.5" Maximum="1"/>
-			<TargetPosControl Range="0.1"/>
+			<TargetPosControl Range="0.025"/>
 			<OtherSettings AllowMotionCmdToSlave="true" PulseDistancePos="0.5" PulseDistanceNeg="0.5"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="7">

--- a/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleVZ.xti
+++ b/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleVZ.xti
@@ -1326,7 +1326,7 @@ External Setpoint Generation:
 		<AxisPara>
 			<Dynamic Acceleration="2" Deceleration="2"/>
 			<Velo RefSearch="0.5" RefSync="0.5" SlowManual="0.25" FastManual="0.5" Maximum="1"/>
-			<TargetPosControl Range="0.1"/>
+			<TargetPosControl Range="0.025"/>
 			<OtherSettings AllowMotionCmdToSlave="true" PulseDistancePos="0.5" PulseDistanceNeg="0.5"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="7">

--- a/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleX.xti
+++ b/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleX.xti
@@ -1352,7 +1352,7 @@ External Setpoint Generation:
 		<AxisPara>
 			<Dynamic Acceleration="2" Deceleration="2" DelayTime="0.008"/>
 			<Velo SlowManual="0.5" FastManual="1" Maximum="1"/>
-			<TargetPosControl Range="0.1"/>
+			<TargetPosControl Range="0.001"/>
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">

--- a/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleY.xti
+++ b/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleY.xti
@@ -1352,7 +1352,7 @@ External Setpoint Generation:
 		<AxisPara>
 			<Dynamic Acceleration="2" Deceleration="2" DelayTime="0.008"/>
 			<Velo SlowManual="0.5" FastManual="1" Maximum="1"/>
-			<TargetPosControl Range="0.1"/>
+			<TargetPosControl Range="0.001"/>
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">

--- a/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleZ.xti
+++ b/lcls-plc-mrco-motion/_Config/NC/Axes/SamplePaddleZ.xti
@@ -1326,7 +1326,7 @@ External Setpoint Generation:
 		<AxisPara>
 			<Dynamic Acceleration="2" Deceleration="2" DelayTime="0.008"/>
 			<Velo SlowManual="0.5" FastManual="1" Maximum="1"/>
-			<TargetPosControl Range="0.1"/>
+			<TargetPosControl Range="0.00625"/>
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">

--- a/lcls-plc-mrco-motion/_Config/NC/Axes/SamplyPaddleVX.xti
+++ b/lcls-plc-mrco-motion/_Config/NC/Axes/SamplyPaddleVX.xti
@@ -1326,7 +1326,7 @@ External Setpoint Generation:
 		<AxisPara>
 			<Dynamic Acceleration="2" Deceleration="2"/>
 			<Velo RefSearch="0.5" RefSync="0.5" SlowManual="0.25" FastManual="0.5" Maximum="1"/>
-			<TargetPosControl Range="0.1"/>
+			<TargetPosControl Range="0.025"/>
 			<OtherSettings AllowMotionCmdToSlave="true" PulseDistancePos="0.5" PulseDistanceNeg="0.5"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="7">

--- a/lcls-plc-mrco-motion/_Config/PLC/mrco_motion.xti
+++ b/lcls-plc-mrco-motion/_Config/PLC/mrco_motion.xti
@@ -2275,27 +2275,6 @@ External Setpoint Generation:
 			<Vars VarGrpType="2">
 				<Name>PlcTask Outputs</Name>
 				<Var>
-					<Name>Main.nVirtualEncoderM7nm</Name>
-					<Comment>
-						<![CDATA[ Virtual Encoder to map to NC axis encoder data input. In 1 nm/count]]>
-					</Comment>
-					<Type>UDINT</Type>
-				</Var>
-				<Var>
-					<Name>Main.nVirtualEncoderM8nm</Name>
-					<Comment>
-						<![CDATA[ Virtual Encoder to map to NC axis encoder data input. In 1 nm/count]]>
-					</Comment>
-					<Type>UDINT</Type>
-				</Var>
-				<Var>
-					<Name>Main.nVirtualEncoderM9nm</Name>
-					<Comment>
-						<![CDATA[ Virtual Encoder to map to NC axis encoder data input. In 1 nm/count]]>
-					</Comment>
-					<Type>UDINT</Type>
-				</Var>
-				<Var>
 					<Name>Main.M1.Axis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
@@ -2429,6 +2408,27 @@ External Setpoint Generation:
 				<Var>
 					<Name>Main.fbMotionStageM9.fbDriveVirtual.MasterAxis.PlcToNc</Name>
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+				</Var>
+				<Var>
+					<Name>Main.nVirtualEncoderM7nm</Name>
+					<Comment>
+						<![CDATA[ Virtual Encoder to map to NC axis encoder data input. In 1 nm/count]]>
+					</Comment>
+					<Type>UDINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.nVirtualEncoderM8nm</Name>
+					<Comment>
+						<![CDATA[ Virtual Encoder to map to NC axis encoder data input. In 1 nm/count]]>
+					</Comment>
+					<Type>UDINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.nVirtualEncoderM9nm</Name>
+					<Comment>
+						<![CDATA[ Virtual Encoder to map to NC axis encoder data input. In 1 nm/count]]>
+					</Comment>
+					<Type>UDINT</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="8">

--- a/lcls-plc-mrco-motion/mrco_motion/POUs/FB_MotionVirtualFrame.TcPOU
+++ b/lcls-plc-mrco-motion/mrco_motion/POUs/FB_MotionVirtualFrame.TcPOU
@@ -1,0 +1,386 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_MotionVirtualFrame" Id="{db4a3323-bc78-4bca-8918-99f0e2117f18}" SpecialFunc="None">
+    <Declaration><![CDATA[
+FUNCTION_BLOCK FB_MotionVirtualFrame
+(*
+Takes 3 ST_MotionStages representing real axes that are orthogonal to each other and in a base frame of reference.
+Takes 3 ST_MotionStages representing virtual axes that are orthogonal to each other and in a new frame of reference.
+Computes the transformation from the base to the new frame of reference using 3 euler angles and a rotation order
+as inputs. By default, the order and angles are interpreted as going from the base to the virtual frame. Can be
+switched to go from virtual to base frame of reference.
+If enabled, this function block will automatically handle commanding the real axes to move when the virtual axes
+are commanded to move. If not enabled, the function block acts as a calculator, outputing the results of
+calculating motions in a new frame of reference, but not changing any setpoints or commanding any moves.
+*)
+VAR_IN_OUT
+    stMotionStageRx : ST_MotionStage; // Real X Axis in base frame of reference
+    stMotionStageRy : ST_MotionStage; // Real Y Axis in base frame of reference
+    stMotionStageRz : ST_MotionStage; // Real Z Axis in base frame of reference
+    stMotionStageVx : ST_MotionStage; // Virtual X Axis in new frame of reference
+    stMotionStageVy : ST_MotionStage; // Virtual Y Axis in new frame of reference
+    stMotionStageVz : ST_MotionStage; // Virtual Z Axis in new frame of reference
+END_VAR
+VAR_INPUT
+    (*TRUE to automatically overwrite real axis setpoints and command moves.
+      FALSE to use this function only as a calculator.*)
+    bEnable : BOOL;
+    fAlphaDegrees : LREAL; // Angle of rotation about first axis.
+    fBetaDegrees : LREAL; // Angle of rotation about second axis.
+    fGammaDegrees : LREAL; // Angle of rotation about third axis.
+    (*Rotation Order. E.g: XYZ to rotate alpha degrees around X axis, beta degrees around Y axis,
+      and gamma degrees around Z axis. Valid rotation orders are:
+      YZY, YXY, ZYZ, ZXZ, XYX, XZX, XYZ, YZX, ZXY, XZY, ZYX, YXZ.
+      Default order for empty or invalid input is: ZYX.*)
+    sOrder : STRING;
+    (*FALSE to define inputs as rotating the frame of reference from the new frame to the base frame.
+      TRUE to define the inputs as rotating the frame of reference from the base from to the new frame.*)
+    bBaseToNew : BOOL := TRUE;
+END_VAR
+VAR_OUTPUT
+    fbVirtActPositionVec3 : FB_Vec3;
+    fbVirtActVelocityVec3 : FB_Vec3;
+    fbVirtActAcceleraVec3 : FB_Vec3;
+
+    fbRealTarPositionVec3 : FB_Vec3;
+    fbRealTarVelocityVec3 : FB_Vec3;
+    fbRealTarAcceleraVec3 : FB_Vec3;
+END_VAR
+VAR
+    fAlphaRadians : LREAL;
+    fBetaRadians : LREAL;
+    fGammaRadians : LREAL;
+
+    rtExecuteVx : R_TRIG;
+    rtExecuteVy : R_TRIG;
+    rtExecuteVz : R_TRIG;
+
+    fbRealActPositionVec3 : FB_Vec3;
+    fbRealActVelocityVec3 : FB_Vec3;
+    fbRealActAcceleraVec3 : FB_Vec3;
+
+    sOrderReversed : STRING;
+    sLeft : STRING;
+    sMid : STRING;
+    sRight : STRING;
+
+    fbVirtTarPositionVec3 : FB_Vec3;
+    fbVirtTarVelocityVec3 : FB_Vec3;
+    fbVirtTarAcceleraVec3 : FB_Vec3;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[
+fAlphaRadians := DegToRad(fAlphaDegrees);
+fBetaRadians := DegToRad(fBetaDegrees);
+fGammaRadians := DegToRad(fGammaDegrees);
+
+rtExecuteVx(CLK := stMotionStageVx.bBusy);
+rtExecuteVy(CLK := stMotionStageVy.bBusy);
+rtExecuteVz(CLK := stMotionStageVz.bBusy);
+
+fbRealActPositionVec3.x := stMotionStageRx.Axis.NcToPlc.ActPos;
+fbRealActPositionVec3.y := stMotionStageRy.Axis.NcToPlc.ActPos;
+fbRealActPositionVec3.z := stMotionStageRz.Axis.NcToPlc.ActPos;
+
+fbRealActVelocityVec3.x := stMotionStageRx.Axis.NcToPlc.ActVelo;
+fbRealActVelocityVec3.y := stMotionStageRy.Axis.NcToPlc.ActVelo;
+fbRealActVelocityVec3.z := stMotionStageRz.Axis.NcToPlc.ActVelo;
+
+fbRealActAcceleraVec3.x := stMotionStageRx.Axis.NcToPlc.ActAcc;
+fbRealActAcceleraVec3.y := stMotionStageRy.Axis.NcToPlc.ActAcc;
+fbRealActAcceleraVec3.z := stMotionStageRz.Axis.NcToPlc.ActAcc;
+
+sOrderReversed := ReverseOrder(sOrder);
+
+IF bBaseToNew THEN
+    RotatePosVelAccFrame(
+        fbBaseFramePositionVec3 := fbRealActPositionVec3,
+        fbBaseFrameVelocityVec3 := fbRealActVelocityVec3,
+        fbBaseFrameAcceleraVec3 := fbRealActAcceleraVec3,
+        fbNewFramePositionVec3 => fbVirtActPositionVec3,
+        fbNewFrameVelocityVec3 => fbVirtActVelocityVec3,
+        fbNewFrameAcceleraVec3 => fbVirtActAcceleraVec3,
+        fAlphaRadians := fAlphaRadians,
+        fBetaRadians := fBetaRadians,
+        fGammaRadians := fGammaRadians,
+        sOrder := sOrder
+    );
+ELSE
+    RotatePosVelAccFrame(
+        fbBaseFramePositionVec3 := fbRealActPositionVec3,
+        fbBaseFrameVelocityVec3 := fbRealActVelocityVec3,
+        fbBaseFrameAcceleraVec3 := fbRealActAcceleraVec3,
+        fbNewFramePositionVec3 => fbVirtActPositionVec3,
+        fbNewFrameVelocityVec3 => fbVirtActVelocityVec3,
+        fbNewFrameAcceleraVec3 => fbVirtActAcceleraVec3,
+        fAlphaRadians := -fGammaRadians,
+        fBetaRadians := -fBetaRadians,
+        fGammaRadians := -fAlphaRadians,
+        sOrder := sOrderReversed
+    );
+END_IF
+
+SetTargetPosVelAcc3D(
+    stMotionStageX := stMotionStageVx,
+    stMotionStageY := stMotionStageVy,
+    stMotionStageZ := stMotionStageVz,
+    fbActPosVec3 := fbVirtActPositionVec3,
+    fbTarPosVec3 => fbVirtTarPositionVec3,
+    fbTarVelVec3 => fbVirtTarVelocityVec3,
+    fbTarAccVec3 => fbVirtTarAcceleraVec3
+);
+
+IF bBaseToNew THEN
+    RotatePosVelAccFrame(
+        fbBaseFramePositionVec3 := fbVirtTarPositionVec3,
+        fbBaseFrameVelocityVec3 := fbVirtTarVelocityVec3,
+        fbBaseFrameAcceleraVec3 := fbVirtTarAcceleraVec3,
+        fbNewFramePositionVec3 => fbRealTarPositionVec3,
+        fbNewFrameVelocityVec3 => fbRealTarVelocityVec3,
+        fbNewFrameAcceleraVec3 => fbRealTarAcceleraVec3,
+        fAlphaRadians := -fGammaRadians,
+        fBetaRadians := -fBetaRadians,
+        fGammaRadians := -fAlphaRadians,
+        sOrder := sOrderReversed
+    );
+ELSE
+    RotatePosVelAccFrame(
+        fbBaseFramePositionVec3 := fbVirtTarPositionVec3,
+        fbBaseFrameVelocityVec3 := fbVirtTarVelocityVec3,
+        fbBaseFrameAcceleraVec3 := fbVirtTarAcceleraVec3,
+        fbNewFramePositionVec3 => fbRealTarPositionVec3,
+        fbNewFrameVelocityVec3 => fbRealTarVelocityVec3,
+        fbNewFrameAcceleraVec3 => fbRealTarAcceleraVec3,
+        fAlphaRadians := fAlphaRadians,
+        fBetaRadians := fBetaRadians,
+        fGammaRadians := fGammaRadians,
+        sOrder := sOrder
+    );
+END_IF
+
+IF bEnable THEN
+    IF rtExecuteVx.Q OR rtExecuteVy.Q OR rtExecuteVz.Q THEN
+        stMotionStageRx.fPosition := fbRealTarPositionVec3.x;
+        stMotionStageRy.fPosition := fbRealTarPositionVec3.y;
+        stMotionStageRz.fPosition := fbRealTarPositionVec3.z;
+
+        stMotionStageRx.fVelocity := ABS(fbRealTarVelocityVec3.x);
+        stMotionStageRy.fVelocity := ABS(fbRealTarVelocityVec3.y);
+        stMotionStageRz.fVelocity := ABS(fbRealTarVelocityVec3.z);
+
+        stMotionStageRx.fAcceleration := ABS(fbRealTarAcceleraVec3.x);
+        stMotionStageRy.fAcceleration := ABS(fbRealTarAcceleraVec3.y);
+        stMotionStageRz.fAcceleration := ABS(fbRealTarAcceleraVec3.z);
+
+        stMotionStageRx.fDeceleration := ABS(fbRealTarAcceleraVec3.x);
+        stMotionStageRy.fDeceleration := ABS(fbRealTarAcceleraVec3.y);
+        stMotionStageRz.fDeceleration := ABS(fbRealTarAcceleraVec3.z);
+
+        IF stMotionStageRx.fVelocity >= 0.001 THEN
+            stMotionStageRx.bMoveCmd := TRUE;
+        ELSIF ABS(stMotionStageRx.fPosition - stMotionStageRx.Axis.NcToPlc.ActPos) >
+                stMotionStageRx.stAxisParameters.fTargetPosControlRange THEN
+            stMotionStageRx.fVelocity := 0.001;
+            stMotionStageRx.bMoveCmd := TRUE;
+        END_IF
+
+        IF stMotionStageRy.fVelocity >= 0.001 THEN
+            stMotionStageRy.bMoveCmd := TRUE;
+        ELSIF ABS(stMotionStageRy.fPosition - stMotionStageRy.Axis.NcToPlc.ActPos) >
+                stMotionStageRy.stAxisParameters.fTargetPosControlRange THEN
+            stMotionStageRy.fVelocity := 0.001;
+            stMotionStageRy.bMoveCmd := TRUE;
+        END_IF
+
+        IF stMotionStageRz.fVelocity >= 0.001 THEN
+            stMotionStageRz.bMoveCmd := TRUE;
+        ELSIF ABS(stMotionStageRz.fPosition - stMotionStageRz.Axis.NcToPlc.ActPos) >
+                stMotionStageRz.stAxisParameters.fTargetPosControlRange THEN
+            stMotionStageRz.fVelocity := 0.001;
+            stMotionStageRz.bMoveCmd := TRUE;
+        END_IF
+    END_IF
+
+    IF stMotionStageRx.bError OR stMotionStageRy.bError OR stMotionStageRz.bError THEN
+        stMotionStageVx.bError := TRUE;
+        stMotionStageVy.bError := TRUE;
+        stMotionStageVz.bError := TRUE;
+        stMotionStageVx.sCustomErrorMessage := 'An error occured in one of the real axes. All virtual axes stopped.';
+        stMotionStageVy.sCustomErrorMessage := 'An error occured in one of the real axes. All virtual axes stopped.';
+        stMotionStageVz.sCustomErrorMessage := 'An error occured in one of the real axes. All virtual axes stopped.';
+    END_IF
+END_IF
+]]></ST>
+    </Implementation>
+    <Method Name="DegToRad" Id="{b3994cfb-0e95-49f7-8a93-c949b8827612}">
+      <Declaration><![CDATA[
+METHOD PUBLIC DegToRad : LREAL
+VAR_INPUT
+    fDeg : LREAL;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+DegToRad := fDeg  / 180.0 * lcls_twincat_math.GVL_Constants.PI;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="ReverseOrder" Id="{ad0bf132-fcf3-412d-9abf-164f39420901}">
+      <Declaration><![CDATA[METHOD ReverseOrder : STRING
+VAR_INPUT
+    sOrder : STRING;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+IF sOrder = '' THEN
+    sOrder := 'ZYX';
+END_IF
+sLeft := LEFT(sOrder, 1);
+sMid := MID(sOrder, 1, 2);
+sRight := RIGHT(sOrder, 1);
+ReverseOrder := CONCAT(sRight, CONCAT(sMid, sLeft));
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="RotatePosVelAccFrame" Id="{61c7d3bf-c97e-4994-9217-9ace0f7272b1}">
+      <Declaration><![CDATA[
+METHOD PUBLIC RotatePosVelAccFrame
+VAR_INPUT
+    fbBaseFramePositionVec3 : FB_Vec3;
+    fbBaseFrameVelocityVec3 : FB_Vec3;
+    fbBaseFrameAcceleraVec3 : FB_Vec3;
+
+    fAlphaRadians : LREAL;
+    fBetaRadians : LREAL;
+    fGammaRadians : LREAL;
+    sOrder : STRING;
+END_VAR
+VAR_OUTPUT
+    fbNewFramePositionVec3 : FB_Vec3;
+    fbNewFrameVelocityVec3 : FB_Vec3;
+    fbNewFrameAcceleraVec3 : FB_Vec3;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+fbNewFramePositionVec3 := F_EulerRotateVec3Frame(
+    iVec3 := fbBaseFramePositionVec3,
+    fAlphaRadians := fAlphaRadians,
+    fBetaRadians := fBetaRadians,
+    fGammaRadians := fGammaRadians,
+    sOrder := sOrder
+);
+
+fbNewFrameVelocityVec3 := F_EulerRotateVec3Frame(
+    iVec3 := fbBaseFrameVelocityVec3,
+    fAlphaRadians := fAlphaRadians,
+    fBetaRadians := fBetaRadians,
+    fGammaRadians := fGammaRadians,
+    sOrder := sOrder
+);
+
+fbNewFrameAcceleraVec3 := F_EulerRotateVec3Frame(
+    iVec3 := fbBaseFrameAcceleraVec3,
+    fAlphaRadians := fAlphaRadians,
+    fBetaRadians := fBetaRadians,
+    fGammaRadians := fGammaRadians,
+    sOrder := sOrder
+);]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="SetTargetPosVelAcc1D" Id="{c0957557-35ec-4203-a92e-41f437a57b08}">
+      <Declaration><![CDATA[
+METHOD PUBLIC SetTargetPosVelAcc1D
+VAR_INPUT
+    stMotionStage : ST_MotionStage;
+    fActPos : LREAL;
+END_VAR
+VAR_OUTPUT
+    fTarPos : LREAL;
+    fTarVel : LREAL;
+    fTarAcc : LREAL;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+IF stMotionStage.bBusy THEN
+    fTarPos := stMotionStage.fPosition;
+    IF fTarPos >= fActPos THEN
+        fTarVel := stMotionStage.fVelocity;
+        fTarAcc := stMotionStage.fAcceleration;
+    ELSE
+        fTarVel := -stMotionStage.fVelocity;
+        fTarAcc := -stMotionStage.fAcceleration;
+    END_IF
+ELSE
+    fTarPos := fActPos;
+    fTarVel := 0.0;
+    fTarAcc := 0.0;
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="SetTargetPosVelAcc3D" Id="{7ca16bbb-14b2-4a45-b834-72e712c8fe8d}">
+      <Declaration><![CDATA[
+METHOD PUBLIC SetTargetPosVelAcc3D
+VAR_INPUT
+    stMotionStageX : ST_MotionStage;
+    stMotionStageY : ST_MotionStage;
+    stMotionStageZ : ST_MotionStage;
+    fbActPosVec3 : FB_Vec3;
+END_VAR
+VAR_OUTPUT
+    fbTarPosVec3 : FB_Vec3;
+    fbTarVelVec3 : FB_Vec3;
+    fbTarAccVec3 : FB_Vec3;
+END_VAR
+VAR
+    fTarPosX : LREAL;
+    fTarPosY : LREAL;
+    fTarPosZ : LREAL;
+
+    fTarVelX : LREAL;
+    fTarVelY : LREAL;
+    fTarVelZ : LREAL;
+
+    fTarAccX : LREAL;
+    fTarAccY : LREAL;
+    fTarAccZ : LREAL;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+SetTargetPosVelAcc1D(
+    stMotionStage := stMotionStageX,
+    fActPos := fbActPosVec3.x,
+    fTarPos => fTarPosX,
+    fTarVel => fTarVelX,
+    fTarAcc => fTarAccX
+);
+
+SetTargetPosVelAcc1D(
+    stMotionStage := stMotionStageY,
+    fActPos := fbActPosVec3.y,
+    fTarPos => fTarPosY,
+    fTarVel => fTarVelY,
+    fTarAcc => fTarAccY
+);
+
+SetTargetPosVelAcc1D(
+    stMotionStage := stMotionStageZ,
+    fActPos := fbActPosVec3.z,
+    fTarPos => fTarPosZ,
+    fTarVel => fTarVelZ,
+    fTarAcc => fTarAccZ
+);
+
+fbTarPosVec3.Set(fTarPosX, fTarPosY, fTarPosZ);
+fbTarVelVec3.Set(fTarVelX, fTarVelY, fTarVelZ);
+fbTarAccVec3.Set(fTarAccX, fTarAccY, fTarAccZ);
+]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/lcls-plc-mrco-motion/mrco_motion/mrco_motion.plcproj
+++ b/lcls-plc-mrco-motion/mrco_motion/mrco_motion.plcproj
@@ -27,6 +27,9 @@
     <Compile Include="POUs\FB_EPSSamplePaddleGasNeedle.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\FB_MotionVirtualFrame.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\F_UpdateMotionTransform3d.TcPOU">
       <SubType>Code</SubType>
     </Compile>
@@ -88,7 +91,7 @@
       <Resolution>lcls-twincat-math, * (SLAC - LCLS)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, 0.0.0 (SLAC)</Resolution>
+      <Resolution>lcls-twincat-motion, 4.2.0 (SLAC)</Resolution>
     </PlaceholderResolution>
   </ItemGroup>
   <ProjectExtensions>

--- a/lcls-plc-mrco-motion/mrco_motion/mrco_motion.tmc
+++ b/lcls-plc-mrco-motion/mrco_motion/mrco_motion.tmc
@@ -1,2960 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{C609DFAC-D03E-F28B-6EFE-983669C3B160}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FEB0BA35-2D93-26FC-1775-F8B82E4D14B9}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
-    <DataType>
-      <Name Namespace="LCLS_General">ST_System</Name>
-      <Comment>Defacto system structure, must be included in all projects</Comment>
-      <BitSize>40</BitSize>
-      <SubItem>
-        <Name>xSwAlmRst</Name>
-        <Type>BOOL</Type>
-        <Comment> Global Alarm Reset - EPICS Command </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xAtVacuum</Name>
-        <Type>BOOL</Type>
-        <Comment> System At Vacuum </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>8</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xFirstScan</Name>
-        <Type>BOOL</Type>
-        <Comment> This boolean is true for the first scan, and is false thereafter, use for initialization of stuff </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xOverrideMode</Name>
-        <Type>BOOL</Type>
-        <Comment>This bit is set when using the override features of the system</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>24</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>xIOState</Name>
-        <Type>BOOL</Type>
-        <Comment> ECat Bus Health </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>analysis</Name>
-          <Value>-33</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">T_MaxString</Name>
-      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
-      <BitSize>2048</BitSize>
-      <BaseType>STRING(255)</BaseType>
-    </DataType>
-    <DataType>
-      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
-      <BitSize>16</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Verbose</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Info</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Warning</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Error</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCEVENTSEVERITY_Critical</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>plcAttribute_qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>plcAttribute_strict</Name>
-        </Property>
-      </Properties>
-      <Hides>
-        <Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
-        <Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">E_Subsystem</Name>
-      <BitSize>16</BitSize>
-      <BaseType>WORD</BaseType>
-      <EnumInfo>
-        <Text>NILVALUE</Text>
-        <Enum>0</Enum>
-        <Comment>Undefined system</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>VACUUM</Text>
-        <Enum>1</Enum>
-        <Comment>Vacuum control system</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MPS</Text>
-        <Enum>2</Enum>
-        <Comment>Machine protection system</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MOTION</Text>
-        <Enum>3</Enum>
-        <Comment>Motion control systems</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FIELDBUS</Text>
-        <Enum>4</Enum>
-        <Comment>EtherCAT networks</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>SDS</Text>
-        <Enum>5</Enum>
-        <Comment>Sample delivery system</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>OPTICS</Text>
-        <Enum>6</Enum>
-        <Comment>Optics control system</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">I_ArgumentsChangeListener</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
-      <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{C3BF7AA5-0A83-4CFA-9A7A-04C1DFD0E5DD}" TcBaseType="true" CName="ITcAsyncResult*">ITcAsyncResult</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
-      <Method>
-        <Name>GetIsBusy</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>bIsBusy</Name>
-          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}" ReferenceTo="true">BOOL32</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetHasError</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>bError</Name>
-          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}" ReferenceTo="true">BOOL32</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>hresult</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}" ReferenceTo="true">HRESULT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Name>
-      <BitSize>64</BitSize>
-      <PropertyItem>
-        <Name>bBusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <GetCodeOffs>79859384</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <GetCodeOffs>79859420</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>hrErrorCode</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-        <BitSize>32</BitSize>
-        <GetCodeOffs>79859428</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>nStringSize</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <GetCodeOffs>79859408</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>sResult</Name>
-        <Type>STRING(255)</Type>
-        <BitSize>2048</BitSize>
-        <GetCodeOffs>79859424</GetCodeOffs>
-      </PropertyItem>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>bBusy</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>b32IsBusy</Name>
-          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>Init</Name>
-        <Parameter>
-          <Name>ipResult</Name>
-          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetString</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>sResult</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nResult</Name>
-          <Comment> buffer size in bytes</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__getnStringSize</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nStringSize</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>pEmpty</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getbError</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Local>
-          <Name>bError</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Local>
-        <Local>
-          <Name>b32HasError</Name>
-          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getsResult</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>sResult</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hrError</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>enable_dynamic_creation</Name>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-        <Property>
-          <Name>no_explicit_call</Name>
-          <Value>do not call this POU directly</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}" TcBaseType="true" CName="TcSourceInfoType">TcSourceInfoType</Name>
-      <BitSize>32</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000008}">UDINT</BaseType>
-      <EnumInfo>
-        <Text>Undefined</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Id</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Guid</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Name</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>plcAttribute_qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>plcAttribute_strict</Name>
-        </Property>
-      </Properties>
-      <Hides>
-        <Hide GUID="{3F74866B-4568-47E2-894F-D4B96829DBD0}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" TcBaseType="true" CName="TcSerializedSourceInfoType">TcSerializedSourceInfoType</Name>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>eType</Name>
-        <Type GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}">TcSourceInfoType</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>obData</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>cbData</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name GUID="{F7BF6767-548B-493C-899B-06A477976F11}" TcBaseType="true" CName="ITcSourceInfo*">ITcSourceInfo</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
-      <Method>
-        <Name>GetNumTypes</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nCount</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetTypes</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ppSourceInfoTypes</Name>
-          <Type GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" PointerTo="2" Const="1">TcSerializedSourceInfoType</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDataSize</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>cbData</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetData</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>ppData</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1" Const="1">PVOID</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" TcBaseType="true" CName="ITcEvent*">ITcEvent</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
-      <Method>
-        <Name>GetEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>eventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}" ReferenceTo="true" Const="1">GUID</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetEventId</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>eventId</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetSeverity</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>severity</Name>
-          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" ReferenceTo="true">TcEventSeverity</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetSourceInfo</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pipSourceInfo</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}" PointerTo="1">ITcSourceInfo</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJsonAttribute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sJsonAttribute</Name>
-          <Type GUID="{18071995-0000-0000-0000-000100000050}" ReferenceTo="true">STRING(80)</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJsonAttribute</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetText</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nLangId</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipResult</Name>
-          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}" PointerTo="1">ITcAsyncStringResult</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetEventClassName</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nLangId</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pipResult</Name>
-          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}" PointerTo="1">ITcAsyncStringResult</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
-      <Method>
-        <Name RpcEnable="plc">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getipData</Name>
-        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}" RpcDirection="out">ITcSourceInfo</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getnId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getsName</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>EqualsTo</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>ipOther</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry">TcEventEntry</Name>
-      <BitSize>192</BitSize>
-      <SubItem>
-        <Name>uuidEventClass</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nEventId</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eSeverity</Name>
-        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
-      <Method>
-        <Name RpcEnable="plc">__geteSeverity</Name>
-        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" RpcDirection="out">TcEventSeverity</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getipSourceInfo</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcSourceInfo</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getnEventId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getsEventClassName</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getsEventText</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getstEventEntry</Name>
-        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
-        <ReturnBitSize>192</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>EqualsTo</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>ipOther</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>EqualsToEventClass</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>OtherEventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>EqualsToEventEntry</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>OtherEventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nOtherEventID</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>eOtherSeverity</Name>
-          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>EqualsToEventEntryEx</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>stOther</Name>
-          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
-          <BitSize>192</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetJsonAttribute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sJsonAttribute</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJsonAttribute</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RequestEventClassName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nLangId</Name>
-          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>sResult</Name>
-          <Comment> buffer for result text</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nResultSize</Name>
-          <Comment> size of buffer in bytes</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>bError</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RequestEventText</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nLangId</Name>
-          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>sResult</Name>
-          <Comment> buffer for result text</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nResultSize</Name>
-          <Comment> size of buffer in bytes</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>bError</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name>IQueryInterface</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__GetInterfacePointer</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2" RpcDirection="in">DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__GetInterfaceReference</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type RpcDirection="in">DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2" RpcDirection="in">DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" TcBaseType="true" CName="TcEventArgumentType">TcEventArgumentType</Name>
-      <BitSize>16</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-      <EnumInfo>
-        <Text>Undefined</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Boolean</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Int8</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Int16</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Int32</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Int64</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>UInt8</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>UInt16</Text>
-        <Enum>7</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>UInt32</Text>
-        <Enum>8</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>UInt64</Text>
-        <Enum>9</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Float</Text>
-        <Enum>10</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Double</Text>
-        <Enum>11</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Char</Text>
-        <Enum>12</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WChar</Text>
-        <Enum>13</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>StringType</Text>
-        <Enum>14</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WStringType</Text>
-        <Enum>15</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EventReference</Text>
-        <Enum>16</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>FormatString</Text>
-        <Enum>17</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ExternalTimestamp</Text>
-        <Enum>18</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>Blob</Text>
-        <Enum>19</Enum>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>plcAttribute_qualified_only</Name>
-        </Property>
-        <Property>
-          <Name>plcAttribute_strict</Name>
-        </Property>
-      </Properties>
-      <Hides>
-        <Hide GUID="{A1C88D80-AC7F-419E-838D-233C8A8C0184}"/>
-      </Hides>
-    </DataType>
-    <DataType>
-      <Name GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" TcBaseType="true" CName="ITcArguments*">ITcArguments</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
-      <Method>
-        <Name>Count</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nCount</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddArgument</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>eType</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}">TcEventArgumentType</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pData</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>cbData</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>Get</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nIndex</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>eType</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" ReferenceTo="true">TcEventArgumentType</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ppData</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1" Const="1">PVOID</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>GetArgumentTypes</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pArgumentTypes</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" PointerTo="1">TcEventArgumentType</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetDataSize</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>cbData</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetData</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pData</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000001}" PointerTo="1">BYTE</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType>IQueryInterface</ExtendsType>
-      <Method>
-        <Name RpcEnable="plc">__getipData</Name>
-        <ReturnType GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" RpcDirection="out">ITcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc">__getnCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>AddBlob</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pData</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>cbData</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddBool</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddByte</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddDInt</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddDWord</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>DWORD</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddEventReferenceEx</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>stEventEntry</Name>
-          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
-          <BitSize>192</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddEventReferenceId</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nEventId</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddEventReferenceIdGuid</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nEventId</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>EventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddInt</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>INT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddLInt</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>LINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddLReal</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>LREAL</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddReal</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>REAL</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddSInt</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>SINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddString</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddStringByValue</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type Namespace="Tc2_System">T_MaxString</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUDInt</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUInt</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>UINT</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddULInt</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUSInt</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>USINT</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddUtf8EncodedString</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddWord</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>WORD</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddWString</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type ReferenceTo="true">WSTRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>AddWStringByValue</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>value</Name>
-          <Type>WSTRING(255)</Type>
-          <BitSize>4096</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{0D73E69C-2D9B-4B12-A5F7-3E8AE9DD2149}" TcBaseType="true" CName="ITcEventUniqueIdProvider*">ITcEventUniqueIdProvider</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
-      <Method>
-        <Name>GetUniqueId</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>id</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Name>
-      <BitSize>2848</BitSize>
-      <Implements Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Implements>
-      <PropertyItem>
-        <Name>nId</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <GetCodeOffs>79859324</GetCodeOffs>
-        <SetCodeOffs>79859348</SetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>sName</Name>
-        <Type>STRING(255)</Type>
-        <BitSize>2048</BitSize>
-        <GetCodeOffs>79859364</GetCodeOffs>
-        <SetCodeOffs>79859376</SetCodeOffs>
-      </PropertyItem>
-      <Method>
-        <Name>ExtendName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>sExtension</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__getipData</Name>
-        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}" RpcDirection="out">ITcSourceInfo</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>ipData</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="3">__getnId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nId</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>ResetToDefault</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>Clear</Name>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="10">__setnId</Name>
-        <Parameter>
-          <Name>nId</Name>
-          <Type RpcDirection="in">UDINT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>monitoring</Name>
-              <Value>call</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__setguid</Name>
-        <Parameter>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="in">GUID</Type>
-          <BitSize>128</BitSize>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>EqualsTo</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>ipOther</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>sName</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="11">__setsName</Name>
-        <Parameter>
-          <Name>sName</Name>
-          <Type RpcDirection="in">STRING(255)</Type>
-          <BitSize>2048</BitSize>
-          <Properties>
-            <Property>
-              <Name>monitoring</Name>
-              <Value>call</Value>
-            </Property>
-            <Property>
-              <Name>TcEncoding</Name>
-              <Value>UTF-8</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>no_explicit_call</Name>
-          <Value>do not call this POU directly</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcEventBase</Name>
-      <BitSize>3424</BitSize>
-      <Implements Namespace="LCLS_General.Tc3_EventLogger">I_ArgumentsChangeListener</Implements>
-      <SubItem>
-        <Name>fbSourceInfo</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
-        <BitSize>2848</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>__REQUESTEVENTCLASSNAME__FBRESULT</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>3232</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>__REQUESTEVENTCLASSNAME__BBUSY</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3296</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>__REQUESTEVENTTEXT__FBRESULT</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>3328</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>__REQUESTEVENTTEXT__BBUSY</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3392</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <PropertyItem>
-        <Name>eSeverity</Name>
-        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-        <BitSize>16</BitSize>
-        <GetCodeOffs>79859476</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>ipSourceInfo</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
-        <BitSize>32</BitSize>
-        <GetCodeOffs>79859456</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>nEventId</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <GetCodeOffs>79859544</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>nUniqueId</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <GetCodeOffs>79859548</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>sEventClassName</Name>
-        <Type>STRING(255)</Type>
-        <BitSize>2048</BitSize>
-        <GetCodeOffs>79859504</GetCodeOffs>
-      </PropertyItem>
-      <PropertyItem>
-        <Name>sEventText</Name>
-        <Type>STRING(255)</Type>
-        <BitSize>2048</BitSize>
-        <GetCodeOffs>79859552</GetCodeOffs>
-      </PropertyItem>
-      <Method>
-        <Name>EqualsToEventClass</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>OtherEventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Parameter>
-        <Local>
-          <Name>_EventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetEventClassName</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nLangId</Name>
-          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>fbResult</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_AsyncStrResult</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>ipTmpEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipResult</Name>
-          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>Release</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>UpdateLangId</Name>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcSourceInfo</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>ipSourceInfo</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>EqualsTo</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>ipOther</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
-        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="3">__getEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
-        <ReturnBitSize>128</ReturnBitSize>
-        <Local>
-          <Name>EventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Local>
-        <Local>
-          <Name>ipTmpEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__geteSeverity</Name>
-        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" RpcDirection="out">TcEventSeverity</ReturnType>
-        <ReturnBitSize>16</ReturnBitSize>
-        <Local>
-          <Name>eSeverity</Name>
-          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-          <BitSize>16</BitSize>
-        </Local>
-        <Local>
-          <Name>ipTmpEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="13">__getstEventEntry</Name>
-        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
-        <ReturnBitSize>192</ReturnBitSize>
-        <Local>
-          <Name>stEventEntry</Name>
-          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
-          <BitSize>192</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>OnCreate</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>EqualsToEventEntry</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>OtherEventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nOtherEventID</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>eOtherSeverity</Name>
-          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>RequestEventText</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nLangId</Name>
-          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>sResult</Name>
-          <Comment> buffer for result text</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nResultSize</Name>
-          <Comment> size of buffer in bytes</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>bError</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>fbResult</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REQUESTEVENTTEXT__FBRESULT</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>bBusy</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REQUESTEVENTTEXT__BBUSY</Value>
-            </Property>
-          </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name>OnArgumentsChanged</Name>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>sEventClassName</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getipArguments</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcArguments</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>ipArguments</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>GetEventText</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nLangId</Name>
-          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>fbResult</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_AsyncStrResult</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>ipTmpEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipResult</Name>
-          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>GetJsonAttribute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sJsonAttribute</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nJsonAttribute</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipTmpEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>RequestEventClassName</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nLangId</Name>
-          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>sResult</Name>
-          <Comment> buffer for result text</Comment>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nResultSize</Name>
-          <Comment> size of buffer in bytes</Comment>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>bError</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>hrErrorCode</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>Output</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Local>
-          <Name>fbResult</Name>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
-          <BitSize>64</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REQUESTEVENTCLASSNAME__FBRESULT</Value>
-            </Property>
-          </Properties>
-        </Local>
-        <Local>
-          <Name>bBusy</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-          <Properties>
-            <Property>
-              <Name>uselocation</Name>
-              <Value>__REQUESTEVENTCLASSNAME__BBUSY</Value>
-            </Property>
-          </Properties>
-        </Local>
-      </Method>
-      <Method>
-        <Name>EqualsToEventEntryEx</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>stOther</Name>
-          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
-          <BitSize>192</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__getnEventId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nEventId</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipTmpEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="10">__getnUniqueId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>nUniqueId</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipTmpEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipProvider</Name>
-          <Type GUID="{0D73E69C-2D9B-4B12-A5F7-3E8AE9DD2149}">ITcEventUniqueIdProvider</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="12">__getsEventText</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
-        <ReturnBitSize>2048</ReturnBitSize>
-        <Local>
-          <Name>sEventText</Name>
-          <Type>STRING(255)</Type>
-          <BitSize>2048</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcEncoding</Name>
-            <Value>UTF-8</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-        <Property>
-          <Name>no_explicit_call</Name>
-          <Value>do not call this POU directly</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</ExtendsType>
-      <Method>
-        <Name>Send</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nTimeStamp</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}" TcBaseType="true" CName="ITcMessage*">ITcMessage</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</BaseType>
-      <Method>
-        <Name>SetJsonAttribute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sJsonAttribute</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000001A}">PCCH</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GetArguments</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>pipArguments</Name>
-          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" PointerTo="1">ITcArguments</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>Send</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>timeStamp</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name GUID="{77D5D639-16DD-48F7-8490-F632AA095917}" TcBaseType="true" CName="ITcMessage2*">ITcMessage2</Name>
-      <BitSize X64="64">32</BitSize>
-      <BaseType GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</BaseType>
-      <Method>
-        <Name>GetTimeSent</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>timeStamp</Name>
-          <Type GUID="{18071995-0000-0000-0000-00000000000B}" ReferenceTo="true">ULINT</Type>
-          <BitSize X64="64">32</BitSize>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Name>
-      <BitSize>3488</BitSize>
-      <ExtendsType Namespace="LCLS_General.Tc3_EventLogger">FB_TcEventBase</ExtendsType>
-      <Implements Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Implements>
-      <PropertyItem>
-        <Name>nTimeSent</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <GetCodeOffs>79859576</GetCodeOffs>
-      </PropertyItem>
-      <Method>
-        <Name>SetJsonAttribute</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>sJsonAttribute</Name>
-          <Type ReferenceTo="true">STRING(80)</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>CreateEx</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>stEventEntry</Name>
-          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
-          <BitSize>192</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ipSourceInfo</Name>
-          <Comment> optional (otherwise a default source info is taken)</Comment>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>Init</Name>
-        <Parameter>
-          <Name>ipMessage</Name>
-          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>ipArguments</Name>
-          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipSourceInfo</Name>
-          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="46">__getnTimeSent</Name>
-        <ReturnType RpcDirection="out">ULINT</ReturnType>
-        <ReturnBitSize>64</ReturnBitSize>
-        <Local>
-          <Name>nTimeSent</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Local>
-          <Name>ipMessage2</Name>
-          <Type GUID="{77D5D639-16DD-48F7-8490-F632AA095917}">ITcMessage2</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>nTimeStamp</Name>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
-            <Name>TcDisplayTypeGUID</Name>
-            <Value>18071995-0000-0000-0000-000000000046</Value>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>Create</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>eventClass</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
-          <BitSize>128</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>nEventId</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>eSeverity</Name>
-          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-          <BitSize>16</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>ipSourceInfo</Name>
-          <Comment> optional (otherwise a default source info is taken)</Comment>
-          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Local>
-          <Name>hr</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>ipArguments</Name>
-          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
-        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Local>
-          <Name>ipEvent</Name>
-          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Properties>
-          <Property>
-            <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </Method>
-      <Method>
-        <Name>Send</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-        <Parameter>
-          <Name>nTimeStamp</Name>
-          <Comment> set 0 to get the current time automatically</Comment>
-          <Type>ULINT</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>Release</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
-        <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>reflection</Name>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-        <Property>
-          <Name>no_explicit_call</Name>
-          <Value>do not call this POU directly</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Standard">F_TRIG</Name>
-      <Comment>
-	Falling Edge detection.
-</Comment>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>CLK</Name>
-        <Type>BOOL</Type>
-        <Comment> signal to detect </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> falling edge at signal detected </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>40</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>48</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Standard">R_TRIG</Name>
-      <Comment>
-	Rising Edge detection.
-</Comment>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>CLK</Name>
-        <Type>BOOL</Type>
-        <Comment> Signal to detect </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Q</Name>
-        <Type>BOOL</Type>
-        <Comment> rising edge at signal detected </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>40</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>M</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>48</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow_all_locals</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_LogMessage</Name>
-      <BitSize>81984</BitSize>
-      <SubItem>
-        <Name>sMsg</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <Comment> Message to send</Comment>
-        <BitSize>2048</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eSevr</Name>
-        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>2080</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>eSubsystem</Name>
-        <Type Namespace="LCLS_General">E_Subsystem</Type>
-        <Comment> Subsystem</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>2096</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sJson</Name>
-        <Type>STRING(7000)</Type>
-        <Comment> JSON to add to the message</Comment>
-        <BitSize>56008</BitSize>
-        <BitOffs>2112</BitOffs>
-        <Default>
-          <String>{}</String>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nMinTimeViolationAcceptable</Name>
-        <Type>INT</Type>
-        <Comment> How many times the min. time can be violated before the CB trips</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>58128</BitOffs>
-        <Default>
-          <Value>5</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nLocalTripThreshold</Name>
-        <Type>TIME</Type>
-        <Comment> Minimum time between calls allowed, pairs with nMinTimeViolationAcceptable</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>58144</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTrickleTripThreshold</Name>
-        <Type>TIME</Type>
-        <Comment> Trickle trip, activated by global threshold, should be &gt;&gt; LocalTripThreshold</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>58176</BitOffs>
-        <Default>
-          <Value>100</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTripResetPeriod</Name>
-        <Type>TIME</Type>
-        <Comment> Time for auto-reset</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>58208</BitOffs>
-        <Default>
-          <Value>600000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bEnableAutoReset</Name>
-        <Type>BOOL</Type>
-        <Comment>Enable circuit breaker auto-reset (true by default)</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>58240</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bInitialized</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>58248</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bInitFailed</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>58256</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>sSubsystemSource</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>58264</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMessage</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcMessage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>58912</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbMessages</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>5</Elements>
-        </ArrayInfo>
-        <BitSize>17440</BitSize>
-        <BitOffs>58944</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbSource</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
-        <BitSize>2848</BitSize>
-        <BitOffs>76384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ipResultMessage</Name>
-        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>79232</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>hr</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>79264</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>hrLastInternalError</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>79296</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eTraceLevel</Name>
-        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>79328</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bFirstCall</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>79344</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>sPath</Name>
-        <Type Namespace="Tc2_System">T_MaxString</Type>
-        <BitSize>2048</BitSize>
-        <BitOffs>79352</BitOffs>
-        <Properties>
-          <Property>
-            <Name>instance-path</Name>
-          </Property>
-          <Property>
-            <Name>noinit</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nTimesViolated</Name>
-        <Type>INT</Type>
-        <Comment>////////////////////////////</Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>81408</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LastCallTime</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CurrentCallTime</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DeltaSinceLastCall</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>WhenTripsCleared</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81664</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftTrippedReleased</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81728</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLocalTrickleTripped</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>81792</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bLocalTripped</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>81800</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bTripped</Name>
-        <Type>BOOL</Type>
-        <Comment> Won't emit messages if true</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>81808</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-            pv: Tripped
-            io: i
-            field: DESC Log message FB tripped
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bResetBreaker</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>81816</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-            pv: Reset
-            io: o
-            field: DESC Rising-edge reset of trip
-        </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rtResetBreaker</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81824</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtTripped</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>81888</BitOffs>
-      </SubItem>
-      <Action>
-        <Name>CircuitBreaker</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>reflection</Name>
-        </Property>
-      </Properties>
-    </DataType>
     <DataType>
       <Name GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}" TcBaseType="true">ST_LibVersion</Name>
       <BitSize>288</BitSize>
@@ -3013,410 +59,10 @@
       </EnumInfo>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_Utilities">E_HashPrefixTypes</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>HASHPREFIX_IEC</Text>
-        <Enum>0</Enum>
-        <Comment> 2#, 8#, 16# </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>HASHPREFIX_STDC</Text>
-        <Enum>1</Enum>
-        <Comment> 0 for octal type, 0x, 0X for hex else none  </Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">E_SBCSType</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>eSBCS_WesternEuropean</Text>
-        <Enum>1</Enum>
-        <Comment> Windows 1252 (default) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eSBCS_CentralEuropean</Text>
-        <Enum>2</Enum>
-        <Comment> Windows 1251 </Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_System">T_AmsNetID</Name>
-      <Comment> TwinCAT AMS netID address string. </Comment>
-      <BitSize>192</BitSize>
-      <BaseType>STRING(23)</BaseType>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">E_RouteTransportType</Name>
-      <BitSize>16</BitSize>
-      <BaseType>UINT</BaseType>
-      <EnumInfo>
-        <Text>eRouteTransport_None</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_TCP_IP</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_IIO_LIGHTBUS</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_PROFIBUS_DP</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_PCI_ISA_BUS</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_ADS_UDP</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_FATP_UDP</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_COM_PORT</Text>
-        <Enum>7</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_USB</Text>
-        <Enum>8</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_CAN_OPEN</Text>
-        <Enum>9</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_DEVICE_NET</Text>
-        <Enum>10</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_SSB</Text>
-        <Enum>11</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>eRouteTransport_SOAP</Text>
-        <Enum>12</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">ST_AmsRouteEntry</Name>
-      <Comment> TwinCAT AMS route entry struct </Comment>
-      <BitSize>1184</BitSize>
-      <SubItem>
-        <Name>sName</Name>
-        <Type>STRING(31)</Type>
-        <Comment> String containing route name </Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sNetID</Name>
-        <Type Namespace="Tc2_System">T_AmsNetID</Type>
-        <Comment> TwinCAT network address (ams net id) </Comment>
-        <BitSize>192</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sAddress</Name>
-        <Type>STRING(79)</Type>
-        <Comment> String containing route network Ipv4 address or host name. </Comment>
-        <BitSize>640</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eTransport</Name>
-        <Type Namespace="Tc2_Utilities">E_RouteTransportType</Type>
-        <Comment> Route transport type </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>tTimeout</Name>
-        <Type>TIME</Type>
-        <Comment> Route timeout </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1120</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwFlags</Name>
-        <Type>DWORD</Type>
-        <Comment> Additional flags </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">E_ArgType</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>ARGTYPE_UNKNOWN</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_BYTE</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_WORD</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_DWORD</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_REAL</Text>
-        <Enum>4</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_LREAL</Text>
-        <Enum>5</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_SINT</Text>
-        <Enum>6</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_INT</Text>
-        <Enum>7</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_DINT</Text>
-        <Enum>8</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_USINT</Text>
-        <Enum>9</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_UINT</Text>
-        <Enum>10</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_UDINT</Text>
-        <Enum>11</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_STRING</Text>
-        <Enum>12</Enum>
-        <Comment> string of type T_MaxString! </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_BOOL</Text>
-        <Enum>13</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_BIGTYPE</Text>
-        <Enum>14</Enum>
-        <Comment> byte buffer </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_ULARGE</Text>
-        <Enum>15</Enum>
-        <Comment> unsigned 64 bit ingeger (T_ULARGE_INTEGER, ULINT) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_UHUGE</Text>
-        <Enum>16</Enum>
-        <Comment> unsigned 128 bit integer (T_UHUGE_INTEGER) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_LARGE</Text>
-        <Enum>17</Enum>
-        <Comment> signed 64 bit integer (T_LARGE_INTEGER, LINT) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_HUGE</Text>
-        <Enum>18</Enum>
-        <Comment> signed 128 bit integer (T_HUGE_INTEGER) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ARGTYPE_LWORD</Text>
-        <Enum>19</Enum>
-        <Comment> LWORD value</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">T_Arg</Name>
-      <Comment> Argument type </Comment>
-      <BitSize>96</BitSize>
-      <SubItem>
-        <Name>eType</Name>
-        <Type Namespace="Tc2_Utilities">E_ArgType</Type>
-        <Comment> Argument data type </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>cbLen</Name>
-        <Type>UDINT</Type>
-        <Comment> Argument data byte length (if eType = ARGTYPE_STRING =&gt; cbLen = length of string + 1 (null delimiter). </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>pData</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Pointer to first argument data byte </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">T_ULARGE_INTEGER</Name>
-      <Comment> 64 bit unsigned integer </Comment>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>dwLowPart</Name>
-        <Type>DWORD</Type>
-        <Comment> Lower double word </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwHighPart</Name>
-        <Type>DWORD</Type>
-        <Comment> Higher double word </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">TIMESTRUCT</Name>
-      <Comment> System Time Structure </Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>wYear</Name>
-        <Type>WORD</Type>
-        <Comment> Year: 1970..2106 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wMonth</Name>
-        <Type>WORD</Type>
-        <Comment> Month: 1..12 (January = 1, February = 2 and so on) </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>16</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wDayOfWeek</Name>
-        <Type>WORD</Type>
-        <Comment> Day of the week: 0..6 (Sunday = 0, Monday = 1, .. , Saturday = 6 and so on) </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wDay</Name>
-        <Type>WORD</Type>
-        <Comment> Day of the month: 1..31 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>48</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wHour</Name>
-        <Type>WORD</Type>
-        <Comment> Hour: 0..23 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wMinute</Name>
-        <Type>WORD</Type>
-        <Comment> Minute: 0..59 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wSecond</Name>
-        <Type>WORD</Type>
-        <Comment> Second: 0..59 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>wMilliseconds</Name>
-        <Type>WORD</Type>
-        <Comment> Milliseconds: 0..999 </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>112</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_Utilities">ST_TimeZoneInformation</Name>
-      <BitSize>864</BitSize>
-      <SubItem>
-        <Name>bias</Name>
-        <Type>DINT</Type>
-        <Comment> Specifies the current bias, in minutes, for local time translation on this computer.
-						The bias is the difference, in minutes, between Coordinated Universal Time (UTC) and local time.
-						UTC = local time + bias </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>standardName</Name>
-        <Type>STRING(31)</Type>
-        <Comment> Specifies a null-terminated string associated with standard time
-								on this operating system. </Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>standardDate</Name>
-        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
-        <Comment>Specifies a SYSTEMTIME structure that contains a date and local time when the
-								transition from daylight saving time to standard time occurs on this operating system.</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>288</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>standardBias</Name>
-        <Type>DINT</Type>
-        <Comment> Specifies a bias value to be used during local time translations that occur during standard time. </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>416</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>daylightName</Name>
-        <Type>STRING(31)</Type>
-        <Comment> Specifies a null-terminated string associated with daylight saving time on this operating system.
-								For example, this member could contain "PDT" to indicate Pacific Daylight Time.</Comment>
-        <BitSize>256</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>daylightDate</Name>
-        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
-        <Comment> Specifies a SYSTEMTIME structure that contains a date and local time when the transition
-								from standard time to daylight saving time occurs on this operating system. </Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>daylightBias</Name>
-        <Type>DINT</Type>
-        <Comment> Specifies a bias value to be used during local time translations that occur during daylight saving time. </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
+      <Name Namespace="Tc2_System">T_MaxString</Name>
+      <Comment> TwinCAT PLC string of max. length of 255 bytes + 1 byte null delimiter. </Comment>
+      <BitSize>2048</BitSize>
+      <BaseType>STRING(255)</BaseType>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Standard">TOF</Name>
@@ -3857,6 +503,59 @@
         <Property>
           <Name>UpperBorder</Name>
           <Value>1000</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">R_TRIG</Name>
+      <Comment>
+	Rising Edge detection.
+</Comment>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>CLK</Name>
+        <Type>BOOL</Type>
+        <Comment> Signal to detect </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> rising edge at signal detected </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>40</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>48</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
         </Property>
       </Properties>
     </DataType>
@@ -5482,6 +2181,133 @@
           <Name>conditionalshow_all_locals</Name>
         </Property>
       </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">E_ArgType</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>ARGTYPE_UNKNOWN</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_BYTE</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_WORD</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_DWORD</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_REAL</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_LREAL</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_SINT</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_INT</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_DINT</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_USINT</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_UINT</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_UDINT</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_STRING</Text>
+        <Enum>12</Enum>
+        <Comment> string of type T_MaxString! </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_BOOL</Text>
+        <Enum>13</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_BIGTYPE</Text>
+        <Enum>14</Enum>
+        <Comment> byte buffer </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_ULARGE</Text>
+        <Enum>15</Enum>
+        <Comment> unsigned 64 bit ingeger (T_ULARGE_INTEGER, ULINT) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_UHUGE</Text>
+        <Enum>16</Enum>
+        <Comment> unsigned 128 bit integer (T_UHUGE_INTEGER) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_LARGE</Text>
+        <Enum>17</Enum>
+        <Comment> signed 64 bit integer (T_LARGE_INTEGER, LINT) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_HUGE</Text>
+        <Enum>18</Enum>
+        <Comment> signed 128 bit integer (T_HUGE_INTEGER) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ARGTYPE_LWORD</Text>
+        <Enum>19</Enum>
+        <Comment> LWORD value</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">T_Arg</Name>
+      <Comment> Argument type </Comment>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>eType</Name>
+        <Type Namespace="Tc2_Utilities">E_ArgType</Type>
+        <Comment> Argument data type </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>cbLen</Name>
+        <Type>UDINT</Type>
+        <Comment> Argument data byte length (if eType = ARGTYPE_STRING =&gt; cbLen = length of string + 1 (null delimiter). </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>pData</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Pointer to first argument data byte </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Utilities">E_TypeFieldParam</Name>
@@ -7564,11 +4390,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>FindTestSuiteInstancePath</Name>
@@ -7827,11 +4648,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_BYTE</Name>
@@ -7933,11 +4749,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -8097,11 +4908,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LTIME</Name>
@@ -8224,11 +5030,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -8370,11 +5171,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -9136,11 +5932,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>SetHasStartedRunning</Name>
@@ -9301,11 +6092,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetHasStartedRunning</Name>
@@ -9408,11 +6194,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -9567,11 +6348,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_DINT</Name>
@@ -9694,11 +6470,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -9874,11 +6645,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -10161,11 +6927,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -10962,11 +7723,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_UDINT</Name>
@@ -11058,11 +7814,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -11554,6 +8305,285 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="Tc2_Utilities">E_HashPrefixTypes</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>HASHPREFIX_IEC</Text>
+        <Enum>0</Enum>
+        <Comment> 2#, 8#, 16# </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>HASHPREFIX_STDC</Text>
+        <Enum>1</Enum>
+        <Comment> 0 for octal type, 0x, 0X for hex else none  </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">E_SBCSType</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>eSBCS_WesternEuropean</Text>
+        <Enum>1</Enum>
+        <Comment> Windows 1252 (default) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eSBCS_CentralEuropean</Text>
+        <Enum>2</Enum>
+        <Comment> Windows 1251 </Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_System">T_AmsNetID</Name>
+      <Comment> TwinCAT AMS netID address string. </Comment>
+      <BitSize>192</BitSize>
+      <BaseType>STRING(23)</BaseType>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">E_RouteTransportType</Name>
+      <BitSize>16</BitSize>
+      <BaseType>UINT</BaseType>
+      <EnumInfo>
+        <Text>eRouteTransport_None</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_TCP_IP</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_IIO_LIGHTBUS</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_PROFIBUS_DP</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_PCI_ISA_BUS</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_ADS_UDP</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_FATP_UDP</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_COM_PORT</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_USB</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_CAN_OPEN</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_DEVICE_NET</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_SSB</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>eRouteTransport_SOAP</Text>
+        <Enum>12</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">ST_AmsRouteEntry</Name>
+      <Comment> TwinCAT AMS route entry struct </Comment>
+      <BitSize>1184</BitSize>
+      <SubItem>
+        <Name>sName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> String containing route name </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sNetID</Name>
+        <Type Namespace="Tc2_System">T_AmsNetID</Type>
+        <Comment> TwinCAT network address (ams net id) </Comment>
+        <BitSize>192</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sAddress</Name>
+        <Type>STRING(79)</Type>
+        <Comment> String containing route network Ipv4 address or host name. </Comment>
+        <BitSize>640</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eTransport</Name>
+        <Type Namespace="Tc2_Utilities">E_RouteTransportType</Type>
+        <Comment> Route transport type </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>1088</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>tTimeout</Name>
+        <Type>TIME</Type>
+        <Comment> Route timeout </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1120</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwFlags</Name>
+        <Type>DWORD</Type>
+        <Comment> Additional flags </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1152</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">T_ULARGE_INTEGER</Name>
+      <Comment> 64 bit unsigned integer </Comment>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>dwLowPart</Name>
+        <Type>DWORD</Type>
+        <Comment> Lower double word </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>dwHighPart</Name>
+        <Type>DWORD</Type>
+        <Comment> Higher double word </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">TIMESTRUCT</Name>
+      <Comment> System Time Structure </Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>wYear</Name>
+        <Type>WORD</Type>
+        <Comment> Year: 1970..2106 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wMonth</Name>
+        <Type>WORD</Type>
+        <Comment> Month: 1..12 (January = 1, February = 2 and so on) </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wDayOfWeek</Name>
+        <Type>WORD</Type>
+        <Comment> Day of the week: 0..6 (Sunday = 0, Monday = 1, .. , Saturday = 6 and so on) </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wDay</Name>
+        <Type>WORD</Type>
+        <Comment> Day of the month: 1..31 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>48</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wHour</Name>
+        <Type>WORD</Type>
+        <Comment> Hour: 0..23 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wMinute</Name>
+        <Type>WORD</Type>
+        <Comment> Minute: 0..59 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>80</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wSecond</Name>
+        <Type>WORD</Type>
+        <Comment> Second: 0..59 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>96</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>wMilliseconds</Name>
+        <Type>WORD</Type>
+        <Comment> Milliseconds: 0..999 </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>112</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Utilities">ST_TimeZoneInformation</Name>
+      <BitSize>864</BitSize>
+      <SubItem>
+        <Name>bias</Name>
+        <Type>DINT</Type>
+        <Comment> Specifies the current bias, in minutes, for local time translation on this computer.
+						The bias is the difference, in minutes, between Coordinated Universal Time (UTC) and local time.
+						UTC = local time + bias </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>standardName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> Specifies a null-terminated string associated with standard time
+								on this operating system. </Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>standardDate</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <Comment>Specifies a SYSTEMTIME structure that contains a date and local time when the
+								transition from daylight saving time to standard time occurs on this operating system.</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>288</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>standardBias</Name>
+        <Type>DINT</Type>
+        <Comment> Specifies a bias value to be used during local time translations that occur during standard time. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>416</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>daylightName</Name>
+        <Type>STRING(31)</Type>
+        <Comment> Specifies a null-terminated string associated with daylight saving time on this operating system.
+								For example, this member could contain "PDT" to indicate Pacific Daylight Time.</Comment>
+        <BitSize>256</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>daylightDate</Name>
+        <Type Namespace="Tc2_Utilities">TIMESTRUCT</Type>
+        <Comment> Specifies a SYSTEMTIME structure that contains a date and local time when the transition
+								from standard time to daylight saving time occurs on this operating system. </Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>daylightBias</Name>
+        <Type>DINT</Type>
+        <Comment> Specifies a bias value to be used during local time translations that occur during daylight saving time. </Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>832</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
       <Name Namespace="lcls_twincat_motion.PMPS">ST_FFInfo</Name>
       <Comment> These elements should be set at init and never changed.</Comment>
       <BitSize>6832</BitSize>
@@ -11743,6 +8773,62 @@
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_Standard">F_TRIG</Name>
+      <Comment>
+	Falling Edge detection.
+</Comment>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>CLK</Name>
+        <Type>BOOL</Type>
+        <Comment> signal to detect </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Q</Name>
+        <Type>BOOL</Type>
+        <Comment> falling edge at signal detected </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>40</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>M</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>48</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
         </Property>
       </Properties>
     </DataType>
@@ -14928,6 +12014,2799 @@
         <Property>
           <Name>no_explicit_call</Name>
           <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Verbose</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Info</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Warning</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Error</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCEVENTSEVERITY_Critical</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+      <Hides>
+        <Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
+        <Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">E_Subsystem</Name>
+      <BitSize>16</BitSize>
+      <BaseType>WORD</BaseType>
+      <EnumInfo>
+        <Text>NILVALUE</Text>
+        <Enum>0</Enum>
+        <Comment>Undefined system</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>VACUUM</Text>
+        <Enum>1</Enum>
+        <Comment>Vacuum control system</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MPS</Text>
+        <Enum>2</Enum>
+        <Comment>Machine protection system</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>MOTION</Text>
+        <Enum>3</Enum>
+        <Comment>Motion control systems</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FIELDBUS</Text>
+        <Enum>4</Enum>
+        <Comment>EtherCAT networks</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>SDS</Text>
+        <Enum>5</Enum>
+        <Comment>Sample delivery system</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>OPTICS</Text>
+        <Enum>6</Enum>
+        <Comment>Optics control system</Comment>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">I_ArgumentsChangeListener</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{C3BF7AA5-0A83-4CFA-9A7A-04C1DFD0E5DD}" TcBaseType="true" CName="ITcAsyncResult*">ITcAsyncResult</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>GetIsBusy</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>bIsBusy</Name>
+          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}" ReferenceTo="true">BOOL32</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetHasError</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>bError</Name>
+          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}" ReferenceTo="true">BOOL32</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>hresult</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}" ReferenceTo="true">HRESULT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Name>
+      <BitSize>64</BitSize>
+      <PropertyItem>
+        <Name>bBusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <GetCodeOffs>79848492</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>bError</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <GetCodeOffs>79848528</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>hrErrorCode</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79848536</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nStringSize</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79848516</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sResult</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+        <GetCodeOffs>79848532</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>bBusy</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>b32IsBusy</Name>
+          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Init</Name>
+        <Parameter>
+          <Name>ipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetString</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sResult</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResult</Name>
+          <Comment> buffer size in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="5">__getnStringSize</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nStringSize</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>pEmpty</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="1">__getbError</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Local>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Local>
+        <Local>
+          <Name>b32HasError</Name>
+          <Type GUID="{9060AE9D-214D-4685-A4C0-CD1082626764}">BOOL32</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getsResult</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sResult</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__gethrErrorCode</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}" RpcDirection="out">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hrError</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>enable_dynamic_creation</Name>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}" TcBaseType="true" CName="TcSourceInfoType">TcSourceInfoType</Name>
+      <BitSize>32</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000008}">UDINT</BaseType>
+      <EnumInfo>
+        <Text>Undefined</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Id</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Guid</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Name</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+      <Hides>
+        <Hide GUID="{3F74866B-4568-47E2-894F-D4B96829DBD0}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" TcBaseType="true" CName="TcSerializedSourceInfoType">TcSerializedSourceInfoType</Name>
+      <BitSize>96</BitSize>
+      <SubItem>
+        <Name>eType</Name>
+        <Type GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}">TcSourceInfoType</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>obData</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>cbData</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name GUID="{F7BF6767-548B-493C-899B-06A477976F11}" TcBaseType="true" CName="ITcSourceInfo*">ITcSourceInfo</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>GetNumTypes</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nCount</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetTypes</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ppSourceInfoTypes</Name>
+          <Type GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" PointerTo="2" Const="1">TcSerializedSourceInfoType</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDataSize</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>cbData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetData</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>ppData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1" Const="1">PVOID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" TcBaseType="true" CName="ITcEvent*">ITcEvent</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>GetEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}" ReferenceTo="true" Const="1">GUID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetEventId</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eventId</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetSeverity</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>severity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" ReferenceTo="true">TcEventSeverity</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetSourceInfo</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}" PointerTo="1">ITcSourceInfo</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type GUID="{18071995-0000-0000-0000-000100000050}" ReferenceTo="true">STRING(80)</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJsonAttribute</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetText</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}" PointerTo="1">ITcAsyncStringResult</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetEventClassName</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000009}">DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}" PointerTo="1">ITcAsyncStringResult</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name RpcEnable="plc">__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getipData</Name>
+        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}" RpcDirection="out">ITcSourceInfo</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getnId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getsName</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EqualsTo</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>ipOther</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry">TcEventEntry</Name>
+      <BitSize>192</BitSize>
+      <SubItem>
+        <Name>uuidEventClass</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nEventId</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eSeverity</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>160</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name RpcEnable="plc">__geteSeverity</Name>
+        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" RpcDirection="out">TcEventSeverity</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getipSourceInfo</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcSourceInfo</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getnEventId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getsEventClassName</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getsEventText</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getstEventEntry</Name>
+        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
+        <ReturnBitSize>192</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EqualsTo</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>ipOther</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EqualsToEventClass</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>OtherEventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EqualsToEventEntry</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>OtherEventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nOtherEventID</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>eOtherSeverity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>EqualsToEventEntryEx</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>stOther</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJsonAttribute</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestEventClassName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sResult</Name>
+          <Comment> buffer for result text</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResultSize</Name>
+          <Comment> size of buffer in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestEventText</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sResult</Name>
+          <Comment> buffer for result text</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResultSize</Name>
+          <Comment> size of buffer in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name>IQueryInterface</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="1">__GetInterfacePointer</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2" RpcDirection="in">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__GetInterfaceReference</Name>
+        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type RpcDirection="in">DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2" RpcDirection="in">DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" TcBaseType="true" CName="TcEventArgumentType">TcEventArgumentType</Name>
+      <BitSize>16</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+      <EnumInfo>
+        <Text>Undefined</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Boolean</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Int8</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Int16</Text>
+        <Enum>3</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Int32</Text>
+        <Enum>4</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Int64</Text>
+        <Enum>5</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UInt8</Text>
+        <Enum>6</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UInt16</Text>
+        <Enum>7</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UInt32</Text>
+        <Enum>8</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UInt64</Text>
+        <Enum>9</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Float</Text>
+        <Enum>10</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Double</Text>
+        <Enum>11</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Char</Text>
+        <Enum>12</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>WChar</Text>
+        <Enum>13</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>StringType</Text>
+        <Enum>14</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>WStringType</Text>
+        <Enum>15</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>EventReference</Text>
+        <Enum>16</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>FormatString</Text>
+        <Enum>17</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>ExternalTimestamp</Text>
+        <Enum>18</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Blob</Text>
+        <Enum>19</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>plcAttribute_qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>plcAttribute_strict</Name>
+        </Property>
+      </Properties>
+      <Hides>
+        <Hide GUID="{A1C88D80-AC7F-419E-838D-233C8A8C0184}"/>
+      </Hides>
+    </DataType>
+    <DataType>
+      <Name GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" TcBaseType="true" CName="ITcArguments*">ITcArguments</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>Count</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nCount</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddArgument</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eType</Name>
+          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}">TcEventArgumentType</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>cbData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Get</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nIndex</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>eType</Name>
+          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" ReferenceTo="true">TcEventArgumentType</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ppData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}" PointerTo="1" Const="1">PVOID</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>GetArgumentTypes</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pArgumentTypes</Name>
+          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" PointerTo="1">TcEventArgumentType</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetDataSize</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>cbData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetData</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000001}" PointerTo="1">BYTE</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType>IQueryInterface</ExtendsType>
+      <Method>
+        <Name RpcEnable="plc">__getipData</Name>
+        <ReturnType GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" RpcDirection="out">ITcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc">__getnCount</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>AddBlob</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pData</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>cbData</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddBool</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddByte</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDInt</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddDWord</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>DWORD</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventReferenceEx</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>stEventEntry</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventReferenceId</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nEventId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddEventReferenceIdGuid</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nEventId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>EventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddInt</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>INT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLInt</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddLReal</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>LREAL</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddReal</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>REAL</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddSInt</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>SINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddString</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddStringByValue</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUDInt</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUInt</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>UINT</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddULInt</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUSInt</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>USINT</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddUtf8EncodedString</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddWord</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>WORD</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddWString</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type ReferenceTo="true">WSTRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>AddWStringByValue</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>value</Name>
+          <Type>WSTRING(255)</Type>
+          <BitSize>4096</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{0D73E69C-2D9B-4B12-A5F7-3E8AE9DD2149}" TcBaseType="true" CName="ITcEventUniqueIdProvider*">ITcEventUniqueIdProvider</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{00000001-0000-0000-E000-000000000064}">ITcUnknown</BaseType>
+      <Method>
+        <Name>GetUniqueId</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>id</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000008}" ReferenceTo="true">UDINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Name>
+      <BitSize>2848</BitSize>
+      <Implements Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Implements>
+      <PropertyItem>
+        <Name>nId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79848432</GetCodeOffs>
+        <SetCodeOffs>79848456</SetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sName</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+        <GetCodeOffs>79848472</GetCodeOffs>
+        <SetCodeOffs>79848484</SetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name>ExtendName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>sExtension</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__getipData</Name>
+        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}" RpcDirection="out">ITcSourceInfo</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>ipData</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="3">__getnId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>ResetToDefault</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>Clear</Name>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="10">__setnId</Name>
+        <Parameter>
+          <Name>nId</Name>
+          <Type RpcDirection="in">UDINT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>monitoring</Name>
+              <Value>call</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="9">__setguid</Name>
+        <Parameter>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="in">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EqualsTo</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>ipOther</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>guid</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sName</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="11">__setsName</Name>
+        <Parameter>
+          <Name>sName</Name>
+          <Type RpcDirection="in">STRING(255)</Type>
+          <BitSize>2048</BitSize>
+          <Properties>
+            <Property>
+              <Name>monitoring</Name>
+              <Value>call</Value>
+            </Property>
+            <Property>
+              <Name>TcEncoding</Name>
+              <Value>UTF-8</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcEventBase</Name>
+      <BitSize>3424</BitSize>
+      <Implements Namespace="LCLS_General.Tc3_EventLogger">I_ArgumentsChangeListener</Implements>
+      <SubItem>
+        <Name>fbSourceInfo</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
+        <BitSize>2848</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__REQUESTEVENTCLASSNAME__FBRESULT</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3232</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__REQUESTEVENTCLASSNAME__BBUSY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3296</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__REQUESTEVENTTEXT__FBRESULT</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>3328</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>__REQUESTEVENTTEXT__BBUSY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>3392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <PropertyItem>
+        <Name>eSeverity</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <GetCodeOffs>79848584</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>ipSourceInfo</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79848564</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nEventId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79848652</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nUniqueId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <GetCodeOffs>79848656</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sEventClassName</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+        <GetCodeOffs>79848612</GetCodeOffs>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sEventText</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+        <GetCodeOffs>79848660</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name>EqualsToEventClass</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>OtherEventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Local>
+          <Name>_EventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetEventClassName</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>fbResult</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_AsyncStrResult</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>Release</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>UpdateLangId</Name>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="8">__getipSourceInfo</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcSourceInfo</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>EqualsTo</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>ipOther</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>ipEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="3">__getEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <ReturnBitSize>128</ReturnBitSize>
+        <Local>
+          <Name>EventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Local>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="2">__geteSeverity</Name>
+        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" RpcDirection="out">TcEventSeverity</ReturnType>
+        <ReturnBitSize>16</ReturnBitSize>
+        <Local>
+          <Name>eSeverity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Local>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="13">__getstEventEntry</Name>
+        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
+        <ReturnBitSize>192</ReturnBitSize>
+        <Local>
+          <Name>stEventEntry</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>OnCreate</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>EqualsToEventEntry</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>OtherEventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nOtherEventID</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>eOtherSeverity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>RequestEventText</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sResult</Name>
+          <Comment> buffer for result text</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResultSize</Name>
+          <Comment> size of buffer in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>fbResult</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REQUESTEVENTTEXT__FBRESULT</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>bBusy</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REQUESTEVENTTEXT__BBUSY</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sEventClassName</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="6">__getipArguments</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcArguments</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>GetEventText</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>fbResult</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_AsyncStrResult</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipResult</Name>
+          <Type GUID="{23293450-14C5-484C-B74F-4E0A8DFD115D}">ITcAsyncStringResult</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>GetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nJsonAttribute</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>RequestEventClassName</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nLangId</Name>
+          <Comment> English(US)=1033 ; German(Germay)=1031</Comment>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>sResult</Name>
+          <Comment> buffer for result text</Comment>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nResultSize</Name>
+          <Comment> size of buffer in bytes</Comment>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bError</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>hrErrorCode</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>Output</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Local>
+          <Name>fbResult</Name>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
+          <BitSize>64</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REQUESTEVENTCLASSNAME__FBRESULT</Value>
+            </Property>
+          </Properties>
+        </Local>
+        <Local>
+          <Name>bBusy</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+          <Properties>
+            <Property>
+              <Name>uselocation</Name>
+              <Value>__REQUESTEVENTCLASSNAME__BBUSY</Value>
+            </Property>
+          </Properties>
+        </Local>
+      </Method>
+      <Method>
+        <Name>EqualsToEventEntryEx</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>stOther</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="9">__getnEventId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nEventId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="10">__getnUniqueId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>nUniqueId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipTmpEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipProvider</Name>
+          <Type GUID="{0D73E69C-2D9B-4B12-A5F7-3E8AE9DD2149}">ITcEventUniqueIdProvider</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="12">__getsEventText</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <ReturnBitSize>2048</ReturnBitSize>
+        <Local>
+          <Name>sEventText</Name>
+          <Type>STRING(255)</Type>
+          <BitSize>2048</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</ExtendsType>
+      <Method>
+        <Name>Send</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nTimeStamp</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}" TcBaseType="true" CName="ITcMessage*">ITcMessage</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</BaseType>
+      <Method>
+        <Name>SetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000001A}">PCCH</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GetArguments</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>pipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" PointerTo="1">ITcArguments</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Send</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>timeStamp</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name GUID="{77D5D639-16DD-48F7-8490-F632AA095917}" TcBaseType="true" CName="ITcMessage2*">ITcMessage2</Name>
+      <BitSize X64="64">32</BitSize>
+      <BaseType GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</BaseType>
+      <Method>
+        <Name>GetTimeSent</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>timeStamp</Name>
+          <Type GUID="{18071995-0000-0000-0000-00000000000B}" ReferenceTo="true">ULINT</Type>
+          <BitSize X64="64">32</BitSize>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Name>
+      <BitSize>3488</BitSize>
+      <ExtendsType Namespace="LCLS_General.Tc3_EventLogger">FB_TcEventBase</ExtendsType>
+      <Implements Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Implements>
+      <PropertyItem>
+        <Name>nTimeSent</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <GetCodeOffs>79848684</GetCodeOffs>
+      </PropertyItem>
+      <Method>
+        <Name>SetJsonAttribute</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>sJsonAttribute</Name>
+          <Type ReferenceTo="true">STRING(80)</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CreateEx</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>stEventEntry</Name>
+          <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+          <BitSize>192</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ipSourceInfo</Name>
+          <Comment> optional (otherwise a default source info is taken)</Comment>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Init</Name>
+        <Parameter>
+          <Name>ipMessage</Name>
+          <Type GUID="{6474ED2C-E483-454E-A67D-233E6D337C08}">ITcMessage</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipSourceInfo</Name>
+          <Type GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="46">__getnTimeSent</Name>
+        <ReturnType RpcDirection="out">ULINT</ReturnType>
+        <ReturnBitSize>64</ReturnBitSize>
+        <Local>
+          <Name>nTimeSent</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Local>
+          <Name>ipMessage2</Name>
+          <Type GUID="{77D5D639-16DD-48F7-8490-F632AA095917}">ITcMessage2</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>nTimeStamp</Name>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>monitoring</Name>
+            <Value>call</Value>
+          </Property>
+          <Property>
+            <Name>TcDisplayTypeGUID</Name>
+            <Value>18071995-0000-0000-0000-000000000046</Value>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Create</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>eventClass</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
+          <BitSize>128</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>nEventId</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>eSeverity</Name>
+          <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+          <BitSize>16</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>ipSourceInfo</Name>
+          <Comment> optional (otherwise a default source info is taken)</Comment>
+          <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Local>
+          <Name>hr</Name>
+          <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>ipArguments</Name>
+          <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Local>
+          <Name>ipEvent</Name>
+          <Type GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Properties>
+          <Property>
+            <Name>property</Name>
+          </Property>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </Method>
+      <Method>
+        <Name>Send</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+        <Parameter>
+          <Name>nTimeStamp</Name>
+          <Comment> set 0 to get the current time automatically</Comment>
+          <Type>ULINT</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>Release</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
+        <ReturnBitSize>32</ReturnBitSize>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
+        </Property>
+        <Property>
+          <Name>conditionalshow_all_locals</Name>
+        </Property>
+        <Property>
+          <Name>no_explicit_call</Name>
+          <Value>do not call this POU directly</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_LogMessage</Name>
+      <BitSize>81984</BitSize>
+      <SubItem>
+        <Name>sMsg</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <Comment> Message to send</Comment>
+        <BitSize>2048</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eSevr</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>2080</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>eSubsystem</Name>
+        <Type Namespace="LCLS_General">E_Subsystem</Type>
+        <Comment> Subsystem</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2096</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sJson</Name>
+        <Type>STRING(7000)</Type>
+        <Comment> JSON to add to the message</Comment>
+        <BitSize>56008</BitSize>
+        <BitOffs>2112</BitOffs>
+        <Default>
+          <String>{}</String>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nMinTimeViolationAcceptable</Name>
+        <Type>INT</Type>
+        <Comment> How many times the min. time can be violated before the CB trips</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>58128</BitOffs>
+        <Default>
+          <Value>5</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nLocalTripThreshold</Name>
+        <Type>TIME</Type>
+        <Comment> Minimum time between calls allowed, pairs with nMinTimeViolationAcceptable</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58144</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTrickleTripThreshold</Name>
+        <Type>TIME</Type>
+        <Comment> Trickle trip, activated by global threshold, should be &gt;&gt; LocalTripThreshold</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58176</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTripResetPeriod</Name>
+        <Type>TIME</Type>
+        <Comment> Time for auto-reset</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>58208</BitOffs>
+        <Default>
+          <Value>600000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bEnableAutoReset</Name>
+        <Type>BOOL</Type>
+        <Comment>Enable circuit breaker auto-reset (true by default)</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>58240</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bInitialized</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>58248</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bInitFailed</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>58256</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>sSubsystemSource</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>58264</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMessage</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger" ReferenceTo="true">FB_TcMessage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>58912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbMessages</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcMessage</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>5</Elements>
+        </ArrayInfo>
+        <BitSize>17440</BitSize>
+        <BitOffs>58944</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbSource</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">FB_TcSourceInfo</Type>
+        <BitSize>2848</BitSize>
+        <BitOffs>76384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ipResultMessage</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcMessage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>79232</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>hr</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>79264</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>hrLastInternalError</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>79296</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>eTraceLevel</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>79328</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bFirstCall</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>79344</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type Namespace="Tc2_System">T_MaxString</Type>
+        <BitSize>2048</BitSize>
+        <BitOffs>79352</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nTimesViolated</Name>
+        <Type>INT</Type>
+        <Comment>////////////////////////////</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>81408</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>LastCallTime</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>81472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>CurrentCallTime</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>81536</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>DeltaSinceLastCall</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>81600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>WhenTripsCleared</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>81664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftTrippedReleased</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>81728</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLocalTrickleTripped</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>81792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bLocalTripped</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>81800</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bTripped</Name>
+        <Type>BOOL</Type>
+        <Comment> Won't emit messages if true</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>81808</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+            pv: Tripped
+            io: i
+            field: DESC Log message FB tripped
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bResetBreaker</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>81816</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+            pv: Reset
+            io: o
+            field: DESC Rising-edge reset of trip
+        </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rtResetBreaker</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>81824</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>rtTripped</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>81888</BitOffs>
+      </SubItem>
+      <Action>
+        <Name>CircuitBreaker</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>reflection</Name>
         </Property>
       </Properties>
     </DataType>
@@ -20967,14 +20846,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>79862640</GetCodeOffs>
+        <GetCodeOffs>79851736</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79862592</GetCodeOffs>
+        <GetCodeOffs>79851688</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -22066,7 +21945,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79862716</GetCodeOffs>
+        <GetCodeOffs>79851812</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -22724,7 +22603,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79862772</GetCodeOffs>
+        <GetCodeOffs>79851868</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -23298,6 +23177,52 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">ST_System</Name>
+      <Comment>Defacto system structure, must be included in all projects</Comment>
+      <BitSize>40</BitSize>
+      <SubItem>
+        <Name>xSwAlmRst</Name>
+        <Type>BOOL</Type>
+        <Comment> Global Alarm Reset - EPICS Command </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xAtVacuum</Name>
+        <Type>BOOL</Type>
+        <Comment> System At Vacuum </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>8</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xFirstScan</Name>
+        <Type>BOOL</Type>
+        <Comment> This boolean is true for the first scan, and is false thereafter, use for initialization of stuff </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>16</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xOverrideMode</Name>
+        <Type>BOOL</Type>
+        <Comment>This bit is set when using the override features of the system</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>24</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>xIOState</Name>
+        <Type>BOOL</Type>
+        <Comment> ECat Bus Health </Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>analysis</Name>
+          <Value>-33</Value>
         </Property>
       </Properties>
     </DataType>
@@ -28730,7 +28655,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">ST_MotionStage</Name>
-      <BitSize>26176</BitSize>
+      <BitSize>25984</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2">AXIS_REF</Type>
@@ -29366,79 +29291,6 @@ External Setpoint Generation:
         pv: PLC:fPosDiff
         io: i
         field: DESC Position lag difference
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bUserBacklashEn</Name>
-        <Type>BOOL</Type>
-        <Comment> Backlash compensation
- Enabled axis backlash compensation</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>25984</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBacklashEn
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Enable Backlash compensation
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bBacklashStatus</Name>
-        <Type>BOOL</Type>
-        <Comment> backlash compensation status</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>25992</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBacklasStatus
-        io: i
-        field: ZNAM DISABLED
-        field: ONAM ENABLED
-        field: DESC Backlash compensation status
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fBacklash</Name>
-        <Type>LREAL</Type>
-        <Comment> Backlash compensation value</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>26048</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fBacklash
-        io: io
-        field: DESC Backlash compensation
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrentBacklash</Name>
-        <Type>LREAL</Type>
-        <Comment> Current Backlash compensation value ?</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>26112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fCurrentBacklash
-        io: i
-        field: DESC Currently applied compensation
     </Value>
           </Property>
         </Properties>
@@ -37058,2220 +36910,6 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="Tc2_MC2">E_DisableMode</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>DisableModeHold</Text>
-        <Enum>0</Enum>
-        <Comment> hold on the last output value (default) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>DisableModeReset</Text>
-        <Enum>1</Enum>
-        <Comment> reset the output value to zero (jump to zero) 
-	DisbaleModeRamp		:= 2 
- ramp down the output to zero (NOT NEEDED YET) </Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_BacklashCompensationOptions</Name>
-      <BitSize>8</BitSize>
-      <SubItem>
-        <Name>_reserved</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_PositionCompensationTableElement</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>Position</Name>
-        <Type>LREAL</Type>
-        <Comment> uncorrected position value (e.g. SetPos) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Compensation</Name>
-        <Type>LREAL</Type>
-        <Comment> additive compensation value </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">E_WorkDirection</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>WorkDirectionNone</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WorkDirectionBoth</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WorkDirectionPositive</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>WorkDirectionNegative</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_PositionCompensationTableParameter</Name>
-      <BitSize>192</BitSize>
-      <SubItem>
-        <Name>MinPosition</Name>
-        <Type>LREAL</Type>
-        <Comment> compensation starts with this position </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>MaxPosition</Name>
-        <Type>LREAL</Type>
-        <Comment> compensation ends with this position </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NoOfTableElements</Name>
-        <Type>UDINT</Type>
-        <Comment> number of entries in table </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Direction</Name>
-        <Type Namespace="Tc2_MC2">E_WorkDirection</Type>
-        <Comment> compensation is just working in the selected working direction </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>160</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>Modulo</Name>
-        <Type>BOOL</Type>
-        <Comment> FALSE: linear axis, TRUE: modulo axis with cyclic period (e.g. 360 degree) </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>176</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_FB_PositionCorrectionTableLookup</Name>
-      <Comment>==========================================================================
- Name:	_FB_PositionCorrectionTableLookup (based on FB_PositionCompensation)	
- Parameter:	returns a compensation value depending on the position of the reference	
-			axis																
-																			
- Author:	 	kbn &amp; HKP														
- Date:		06-July-2012														
- last edit:	VER 2.0.0														
-==========================================================================</Comment>
-      <BitSize>1472</BitSize>
-      <SubItem>
-        <Name>Axis</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable</Name>
-        <Type>BOOL</Type>
-        <Comment> rising edge triggers initialize routine </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pTable</Name>
-        <Type Namespace="Tc2_MC2" PointerTo="1">ST_PositionCompensationTableElement</Type>
-        <Comment> pointer to table of this type </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TableSize</Name>
-        <Type>UDINT</Type>
-        <Comment> size of data in bytes related to 'pTable' </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TableParameter</Name>
-        <Type Namespace="Tc2_MC2">ST_PositionCompensationTableParameter</Type>
-        <Comment> position compensation table parameter structure </Comment>
-        <BitSize>192</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Compensation</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Active</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nState</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwSize</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>eActiveDirection</Name>
-        <Type Namespace="Tc2_MC2">E_WorkDirection</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>608</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bExecCalc</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>624</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stElement1</Name>
-        <Type Namespace="Tc2_MC2">ST_PositionCompensationTableElement</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stElement2</Name>
-        <Type Namespace="Tc2_MC2">ST_PositionCompensationTableElement</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nLeftIndex</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSetPos</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>pTmpTable</Name>
-        <Type Namespace="Tc2_MC2" PointerTo="1">ST_PositionCompensationTableElement</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTmpStep</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTmpA</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTmpB</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTmpDelta1</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1280</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fTmpDelta2</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ERRORCODE_PARAMSIZE</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1408</BitOffs>
-        <Default>
-          <Value>19267</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ERRORCODE_PARAMPOS</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1440</BitOffs>
-        <Default>
-          <Value>19268</Value>
-        </Default>
-      </SubItem>
-      <Action>
-        <Name>ActIsCompensationDirection</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">E_AxisPositionCorrectionMode</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>POSITIONCORRECTION_MODE_UNLIMITED</Text>
-        <Enum>0</Enum>
-        <Comment> no limitation - pass correction immediately </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>POSITIONCORRECTION_MODE_FAST</Text>
-        <Enum>1</Enum>
-        <Comment> limitatation to maximum position change per cycle </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>POSITIONCORRECTION_MODE_FULLLENGTH</Text>
-        <Enum>2</Enum>
-        <Comment> limitation uses full length to adapt to correction in small steps </Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_PositionCorrectionLimiter</Name>
-      <BitSize>1280</BitSize>
-      <SubItem>
-        <Name>Axis</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PositionCorrectionValue</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CorrectionMode</Name>
-        <Type Namespace="Tc2_MC2">E_AxisPositionCorrectionMode</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Acceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CorrectionLength</Name>
-        <Type>LREAL</Type>
-        <Comment> optional length - comparable to 'superposition length' </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>392</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>416</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Limiting</Name>
-        <Type>BOOL</Type>
-        <Comment> function block is currently limiting the Position Correction </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GetThisTaskIndex</Name>
-        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>MaxDeltaVelocity</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>MaxDeltaPosition</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DeltaCorrection</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>832</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InitialDeltaCorrection</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>EndOfEnablePhase</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>960</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iCorrectionMode</Name>
-        <Type Namespace="Tc2_MC2">E_AxisPositionCorrectionMode</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>976</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>state</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>992</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NumberOfCycles</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>1024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>DeltaCorrectionPerCycle</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1088</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LastPositionCorrectionValue</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1152</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LastPositionCorrection</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>1216</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">E_ReadMode</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>READMODE_ONCE</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>READMODE_CYCLIC</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_AxisParameter</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>CommandedPosition</Text>
-        <Enum>1</Enum>
-        <Comment> taken from NcToPlc </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>SWLimitPos</Text>
-        <Enum>2</Enum>
-        <Comment> IndexOffset= 16#0001_000E </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>SWLimitNeg</Text>
-        <Enum>3</Enum>
-        <Comment> IndexOffset= 16#0001_000D </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EnableLimitPos</Text>
-        <Enum>4</Enum>
-        <Comment> IndexOffset= 16#0001_000C </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EnableLimitNeg</Text>
-        <Enum>5</Enum>
-        <Comment> IndexOffset= 16#0001_000B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>EnablePosLagMonitoring</Text>
-        <Enum>6</Enum>
-        <Comment> IndexOffset= 16#0002_0010 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxPositionLag</Text>
-        <Enum>7</Enum>
-        <Comment> IndexOffset= 16#0002_0012 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxVelocitySystem</Text>
-        <Enum>8</Enum>
-        <Comment> IndexOffset= 16#0000_0027 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxVelocityAppl</Text>
-        <Enum>9</Enum>
-        <Comment> IndexOffset= 16#0000_0027 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>ActualVelocity</Text>
-        <Enum>10</Enum>
-        <Comment> taken from NcToPlc </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>CommandedVelocity</Text>
-        <Enum>11</Enum>
-        <Comment> taken from NcToPlc </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxAccelerationSystem</Text>
-        <Enum>12</Enum>
-        <Comment> IndexOffset= 16#0000_0101 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxAccelerationAppl</Text>
-        <Enum>13</Enum>
-        <Comment> IndexOffset= 16#0000_0101 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxDecelerationSystem</Text>
-        <Enum>14</Enum>
-        <Comment> IndexOffset= 16#0000_0102 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxDecelerationAppl</Text>
-        <Enum>15</Enum>
-        <Comment> IndexOffset= 16#0000_0102 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxJerkSystem</Text>
-        <Enum>16</Enum>
-        <Comment> IndexOffset= 16#0000_0103 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxJerkAppl</Text>
-        <Enum>17</Enum>
-        <Comment> IndexOffset= 16#0000_0103 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisId</Text>
-        <Enum>1000</Enum>
-        <Comment> IndexOffset= 16#0000_0001 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisVeloManSlow</Text>
-        <Enum>1001</Enum>
-        <Comment> IndexOffset= 16#0000_0008 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisVeloManFast</Text>
-        <Enum>1002</Enum>
-        <Comment> IndexOffset= 16#0000_0009 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisVeloMax</Text>
-        <Enum>1003</Enum>
-        <Comment> IndexOffset= 16#0000_0027 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisAcc</Text>
-        <Enum>1004</Enum>
-        <Comment> IndexOffset= 16#0000_0101 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDec</Text>
-        <Enum>1005</Enum>
-        <Comment> IndexOffset= 16#0000_0102 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisJerk</Text>
-        <Enum>1006</Enum>
-        <Comment> IndexOffset= 16#0000_0103 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>MaxJerk</Text>
-        <Enum>1007</Enum>
-        <Comment> IndexOffset= 16#0000_0103 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMaxVelocity</Text>
-        <Enum>1008</Enum>
-        <Comment> IndexOffset= 16#0000_0027 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisRapidTraverseVelocity</Text>
-        <Enum>1009</Enum>
-        <Comment> IndexOffset= 16#0000_000A </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisManualVelocityFast</Text>
-        <Enum>1010</Enum>
-        <Comment> IndexOffset= 16#0000_0009 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisManualVelocitySlow</Text>
-        <Enum>1011</Enum>
-        <Comment> IndexOffset= 16#0000_0008 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCalibrationVelocityForward</Text>
-        <Enum>1012</Enum>
-        <Comment> IndexOffset= 16#0000_0006 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCalibrationVelocityBackward</Text>
-        <Enum>1013</Enum>
-        <Comment> IndexOffset= 16#0000_0007 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisJogIncrementForward</Text>
-        <Enum>1014</Enum>
-        <Comment> IndexOffset= 16#0000_0018 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisJogIncrementBackward</Text>
-        <Enum>1015</Enum>
-        <Comment> IndexOffset= 16#0000_0019 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnMinSoftPosLimit</Text>
-        <Enum>1016</Enum>
-        <Comment> IndexOffset= 16#0001_000B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMinSoftPosLimit</Text>
-        <Enum>1017</Enum>
-        <Comment> IndexOffset= 16#0001_000D </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnMaxSoftPosLimit</Text>
-        <Enum>1018</Enum>
-        <Comment> IndexOffset= 16#0001_000C </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMaxSoftPosLimit</Text>
-        <Enum>1019</Enum>
-        <Comment> IndexOffset= 16#0001_000E </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnPositionLagMonitoring</Text>
-        <Enum>1020</Enum>
-        <Comment> IndexOffset= 16#0002_0010 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMaxPosLagValue</Text>
-        <Enum>1021</Enum>
-        <Comment> IndexOffset= 16#0002_0012 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMaxPosLagFilterTime</Text>
-        <Enum>1022</Enum>
-        <Comment> IndexOffset= 16#0002_0013 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnPositionRangeMonitoring</Text>
-        <Enum>1023</Enum>
-        <Comment> IndexOffset= 16#0000_000F </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisPositionRangeWindow</Text>
-        <Enum>1024</Enum>
-        <Comment> IndexOffset= 16#0000_0010 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnTargetPositionMonitoring</Text>
-        <Enum>1025</Enum>
-        <Comment> IndexOffset= 16#0000_0015 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisTargetPositionWindow</Text>
-        <Enum>1026</Enum>
-        <Comment> IndexOffset= 16#0000_0016 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisTargetPositionMonitoringTime</Text>
-        <Enum>1027</Enum>
-        <Comment> IndexOffset= 16#0000_0017 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnInTargetTimeout</Text>
-        <Enum>1028</Enum>
-        <Comment> IndexOffset= 16#0000_0029 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisInTargetTimeout</Text>
-        <Enum>1029</Enum>
-        <Comment> IndexOffset= 16#0000_002A </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnMotionMonitoring</Text>
-        <Enum>1030</Enum>
-        <Comment> IndexOffset= 16#0000_0011 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMotionMonitoringWindow</Text>
-        <Enum>1031</Enum>
-        <Comment> IndexOffset= 16#0000_0028 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMotionMonitoringTime</Text>
-        <Enum>1032</Enum>
-        <Comment> IndexOffset= 16#0000_0012 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDelayTimeVeloPosition</Text>
-        <Enum>1033</Enum>
-        <Comment> IndexOffset= 16#0000_0104 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnLoopingDistance</Text>
-        <Enum>1034</Enum>
-        <Comment> IndexOffset= 16#0000_0013 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisLoopingDistance</Text>
-        <Enum>1035</Enum>
-        <Comment> IndexOffset= 16#0000_0014 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnBacklashCompensation</Text>
-        <Enum>1036</Enum>
-        <Comment> IndexOffset= 16#0000_002B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisBacklash</Text>
-        <Enum>1037</Enum>
-        <Comment> IndexOffset= 16#0000_002C </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnDataPersistence</Text>
-        <Enum>1038</Enum>
-        <Comment> IndexOffset= 16#0000_0030 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisRefVeloOnRefOutput</Text>
-        <Enum>1039</Enum>
-        <Comment> IndexOffset= 16#0003_0101 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisOverrideType</Text>
-        <Enum>1040</Enum>
-        <Comment> IndexOffset= 16#0000_0105 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderScalingFactor</Text>
-        <Enum>1041</Enum>
-        <Comment> IndexOffset= 16#0001_0006 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderOffset</Text>
-        <Enum>1042</Enum>
-        <Comment> IndexOffset= 16#0001_0007 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderDirectionInverse</Text>
-        <Enum>1043</Enum>
-        <Comment> IndexOffset= 16#0001_0008 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderMask</Text>
-        <Enum>1044</Enum>
-        <Comment> IndexOffset= 16#0001_0015 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderModuloValue</Text>
-        <Enum>1045</Enum>
-        <Comment> IndexOffset= 16#0001_0009 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisModuloToleranceWindow</Text>
-        <Enum>1046</Enum>
-        <Comment> IndexOffset= 16#0001_001B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEnablePosCorrection</Text>
-        <Enum>1047</Enum>
-        <Comment> IndexOffset= 16#0001_0016 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisPosCorrectionFilterTime</Text>
-        <Enum>1048</Enum>
-        <Comment> IndexOffset= 16#0001_0017 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisUnitInterpretation</Text>
-        <Enum>1049</Enum>
-        <Comment> added 5/20/2008 KSt </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMotorDirectionInverse</Text>
-        <Enum>1050</Enum>
-        <Comment> IndexOffset= 16#0003_0006 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCycleTime</Text>
-        <Enum>1051</Enum>
-        <Comment> IndexOffset= 16#0000_0004 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisFastStopSignalType</Text>
-        <Enum>1052</Enum>
-        <Comment> IndexOffset= 16#0000_001E </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisFastAcc</Text>
-        <Enum>1053</Enum>
-        <Comment> IndexOffset= 16#0000_010A </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisFastDec</Text>
-        <Enum>1054</Enum>
-        <Comment> IndexOffset= 16#0000_010B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisFastJerk</Text>
-        <Enum>1055</Enum>
-        <Comment> IndexOffset= 16#0000_010C </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderScalingNumerator</Text>
-        <Enum>1056</Enum>
-        <Comment> IndexOffset= 16#0001_0023 - available in Tc3 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderScalingDenominator</Text>
-        <Enum>1057</Enum>
-        <Comment> IndexOffset= 16#0001_0024 - available in Tc3 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMaximumAcceleration</Text>
-        <Enum>1058</Enum>
-        <Comment> IndexOffset= 16#0000_00F1 - available in Tc3 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMaximumDeceleration</Text>
-        <Enum>1059</Enum>
-        <Comment> IndexOffset= 16#0000_00F2 - available in Tc3 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisVeloJumpFactor</Text>
-        <Enum>1060</Enum>
-        <Comment> IndexOffset= 16#0000_0106 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisToleranceBallAuxAxis</Text>
-        <Enum>1061</Enum>
-        <Comment> IndexOffset= 16#0000_0108 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMaxPositionDeviationAuxAxis</Text>
-        <Enum>1062</Enum>
-        <Comment> IndexOffset= 16#0000_0109 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisErrorPropagationMode</Text>
-        <Enum>1063</Enum>
-        <Comment> IndexOffset= 16#0000_001A </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisErrorPropagationDelay</Text>
-        <Enum>1064</Enum>
-        <Comment> IndexOffset= 16#0000_001B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCoupleSlaveToActualValues</Text>
-        <Enum>1065</Enum>
-        <Comment> IndexOffset= 16#0000_001C </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisAllowMotionCmdToSlaveAxis</Text>
-        <Enum>1066</Enum>
-        <Comment> IndexOffset= 16#0000_0020 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisAllowMotionCmdToExtSetAxis</Text>
-        <Enum>1067</Enum>
-        <Comment> IndexOffset= 16#0000_0021 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderSubMask</Text>
-        <Enum>1068</Enum>
-        <Comment> IndexOffset= 16#0001_0108 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderReferenceSystem</Text>
-        <Enum>1069</Enum>
-        <Comment> IndexOffset= 16#0001_0019 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderPositionFilterPT1</Text>
-        <Enum>1070</Enum>
-        <Comment> IndexOffset= 16#0001_0010 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderVelocityFilterPT1</Text>
-        <Enum>1071</Enum>
-        <Comment> IndexOffset= 16#0001_0011 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderAccelerationFilterPT1</Text>
-        <Enum>1072</Enum>
-        <Comment> IndexOffset= 16#0001_0012 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderMode</Text>
-        <Enum>1073</Enum>
-        <Comment> IndexOffset= 16#0001_000A </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderHomingInvDirCamSearch</Text>
-        <Enum>1074</Enum>
-        <Comment> IndexOffset= 16#0001_0101 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderHomingInvDirSyncSearch</Text>
-        <Enum>1075</Enum>
-        <Comment> IndexOffset= 16#0001_0102 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderHomingCalibValue</Text>
-        <Enum>1076</Enum>
-        <Comment> IndexOffset= 16#0001_0103 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderReferenceMode</Text>
-        <Enum>1077</Enum>
-        <Comment> IndexOffset= 16#0001_0107 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisRefVeloOutputRatio</Text>
-        <Enum>1078</Enum>
-        <Comment> IndexOffset= 16#0003_0102 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDrivePositionOutputScaling</Text>
-        <Enum>1079</Enum>
-        <Comment> IndexOffset= 16#0003_0109 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDriveVelocityOutputScaling</Text>
-        <Enum>1080</Enum>
-        <Comment> IndexOffset= 16#0003_0105 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDriveVelocityOutputDelay</Text>
-        <Enum>1081</Enum>
-        <Comment> IndexOffset= 16#0003_010D </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDriveMinOutputLimitation</Text>
-        <Enum>1082</Enum>
-        <Comment> IndexOffset= 16#0003_000B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDriveMaxOutputLimitation</Text>
-        <Enum>1083</Enum>
-        <Comment> IndexOffset= 16#0003_000C </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisTorqueInputScaling</Text>
-        <Enum>1084</Enum>
-        <Comment> IndexOffset= 16#0003_0031 - available in Tc3 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisTorqueInputFilterPT1</Text>
-        <Enum>1085</Enum>
-        <Comment> IndexOffset= 16#0003_0032 - available in Tc3 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisTorqueDerivationInputFilterPT1</Text>
-        <Enum>1086</Enum>
-        <Comment> IndexOffset= 16#0003_0033 - available in Tc3 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisTorqueOutputScaling</Text>
-        <Enum>1087</Enum>
-        <Comment> IndexOffset= 16#0003_010B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisTorqueOutputDelay</Text>
-        <Enum>1088</Enum>
-        <Comment> IndexOffset= 16#0003_010F </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisAccelerationOutputScaling</Text>
-        <Enum>1089</Enum>
-        <Comment> IndexOffset= 16#0003_010A </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisAccelerationOutputDelay</Text>
-        <Enum>1090</Enum>
-        <Comment> IndexOffset= 16#0003_010E </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDrivePosOutputSmoothFilterType</Text>
-        <Enum>1091</Enum>
-        <Comment> IndexOffset= 16#0003_0110 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDrivePosOutputSmoothFilterTime</Text>
-        <Enum>1092</Enum>
-        <Comment> IndexOffset= 16#0003_0111 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDrivePosOutputSmoothFilterOrder</Text>
-        <Enum>1093</Enum>
-        <Comment> IndexOffset= 16#0003_0112 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDriveMode</Text>
-        <Enum>1094</Enum>
-        <Comment> IndexOffset= 16#0003_000A </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisDriftCompensationOffset</Text>
-        <Enum>1095</Enum>
-        <Comment> IndexOffset= 16#0003_0104 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisPositionControlKv</Text>
-        <Enum>1096</Enum>
-        <Comment> IndexOffset= 16#0002_0102 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCtrlVelocityPreCtrlWeight</Text>
-        <Enum>1097</Enum>
-        <Comment> IndexOffset= 16#0002_000B </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisControllerMode</Text>
-        <Enum>1098</Enum>
-        <Comment> IndexOffset= 16#0002_000A </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCtrlAutoOffset</Text>
-        <Enum>1099</Enum>
-        <Comment> IndexOffset= 16#0002_0110 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCtrlAutoOffsetTimer</Text>
-        <Enum>1100</Enum>
-        <Comment> IndexOffset= 16#0002_0115 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCtrlAutoOffsetLimit</Text>
-        <Enum>1101</Enum>
-        <Comment> IndexOffset= 16#0002_0114 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisSlaveCouplingControlKcp</Text>
-        <Enum>1102</Enum>
-        <Comment> IndexOffset= 16#0002_010F </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisCtrlOutputLimit</Text>
-        <Enum>1103</Enum>
-        <Comment> IndexOffset= 16#0002_0100 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisFadingAccleration</Text>
-        <Enum>1104</Enum>
-        <Comment> IndexOffset= 16#0000_001D </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisUserDataIdxOffs</Text>
-        <Enum>1105</Enum>
-        <Comment> IndexOffset= 16#0000_010D </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisTargetPosition</Text>
-        <Enum>2000</Enum>
-        <Comment> IndexOffset= 16#0000_0013 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisRemainingTimeToGo</Text>
-        <Enum>2001</Enum>
-        <Comment> IndexOffset= 16#0000_0014 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisRemainingDistanceToGo</Text>
-        <Enum>2002</Enum>
-        <Comment> IndexOffset= 16#0000_0022, 16#0000_0042 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisGearRatio</Text>
-        <Enum>3000</Enum>
-        <Comment> read:IdxGrp=0x4100+ID, IdxOffs=16#0000_0022, write:IdxGrp=0x4200+ID, IdxOffs=16#0000_0042 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcSafCycleTime</Text>
-        <Enum>4000</Enum>
-        <Comment> IndexOffset= 16#0000_0010 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>NcSvbCycleTime</Text>
-        <Enum>4001</Enum>
-        <Comment> IndexOffset= 16#0000_0012 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderMask64</Text>
-        <Enum>5000</Enum>
-        <Comment> IndexOffset= 16#0001_0015 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisEncoderSubMask64</Text>
-        <Enum>5001</Enum>
-        <Comment> IndexOffset= 16#0001_0108 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>AxisMasPositionDeviationAuxAxis</Text>
-        <Enum>32000</Enum>
-        <Comment> lreal 
- IndexOffset= 16#0000_0109 
- added for compatibility reasons (write error AxisMasPositionDeviationAuxAxis changed to AxisMaxPositionDeviationAuxAxis) 2018-05-03 KSt </Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_E_ParameterType</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>PARAMETERTYPE_NOTYPE</Text>
-        <Enum>0</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PARAMETERTYPE_BOOL</Text>
-        <Enum>1</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PARAMETERTYPE_DWORD</Text>
-        <Enum>2</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PARAMETERTYPE_LREAL</Text>
-        <Enum>3</Enum>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>PARAMETERTYPE_LARGE</Text>
-        <Enum>4</Enum>
-        <Comment> any parameter with size &gt; LREAL; used for LINT or ULINT as well</Comment>
-      </EnumInfo>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_ST_ParaStruct</Name>
-      <BitSize>192</BitSize>
-      <SubItem>
-        <Name>Port</Name>
-        <Type>UINT</Type>
-        <Comment> 2014-07-14 KSt </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>IndexGroup</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>IndexOffset</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ParaType</Name>
-        <Type Namespace="Tc2_MC2">_E_ParameterType</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LrealSize</Name>
-        <Type>UDINT</Type>
-        <Comment> sizeof Lreal data array </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>LrealOffset</Name>
-        <Type>UDINT</Type>
-        <Comment> offset in lreal data array </Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_FB_ReadWriteParameter</Name>
-      <BitSize>3840</BitSize>
-      <SubItem>
-        <Name>Axis</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ParameterNumber</Name>
-        <Type Namespace="Tc2_MC2">MC_AxisParameter</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Mode</Name>
-        <Type>INT</Type>
-        <Comment> read/write </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ParameterPointer</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> for structured parameters - KSt 2021-03-04</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ParameterSize</Name>
-        <Type>USINT</Type>
-        <Comment> for structured parameters  - KSt 2021-03-04</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Done</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>168</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>176</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>184</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ValueLreal</Name>
-        <Type ReferenceTo="true">LREAL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ValueDword</Name>
-        <Type ReferenceTo="true">DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ValueBool</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iState</Name>
-        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>352</BitOffs>
-        <Default>
-          <Value>100</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsRead</Name>
-        <Type Namespace="Tc2_System">ADSREAD</Type>
-        <BitSize>1248</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsWrite</Name>
-        <Type Namespace="Tc2_System">ADSWRITE</Type>
-        <BitSize>1216</BitSize>
-        <BitOffs>1632</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwValue</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>2848</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>lrValue</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>10</Elements>
-        </ArrayInfo>
-        <BitSize>640</BitSize>
-        <BitOffs>2880</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>NcBoolValue</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>3520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bStarted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>3536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stParaStruct</Name>
-        <Type Namespace="Tc2_MC2">_ST_ParaStruct</Type>
-        <BitSize>192</BitSize>
-        <BitOffs>3552</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>n</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>3744</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>i</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>3760</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ParaLREAL</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>3776</BitOffs>
-        <Default>
-          <Value>2</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_ReadParameter</Name>
-      <BitSize>4288</BitSize>
-      <SubItem>
-        <Name>Axis</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ParameterNumber</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ReadMode</Name>
-        <Type Namespace="Tc2_MC2">E_ReadMode</Type>
-        <Comment> Beckhoff proprietary input </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Valid</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>112</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>120</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Value</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbReadWriteParameter</Name>
-        <Type Namespace="Tc2_MC2">_FB_ReadWriteParameter</Type>
-        <BitSize>3840</BitSize>
-        <BitOffs>320</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>dwValue</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>4160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValue</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>4192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bStarted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>4200</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbTrigger</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>4224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_BacklashCompensation</Name>
-      <Comment>==============================================================================
- Name:	MC_BacklashCompensation												
-		(based on _FB_PositionCorrectionTableLookup + MC_PositionCorrectionLimiter)	
- Parameter: returns a compensation value depending on the position of the reference axis	
-		Use the nc function PositionCompensation to compensate the backlash			
-		1. the FB _FB_PositionCorrectionTableLookup calculates the backlash value		
-		2. the FB MC_PositionCorrectionLimiter feed this correction value					
-		into the NcToPlc.PositionCorrection variable									
- Requirements: The 'Position Correction' feature must be enabled in the SystemManager 	
-																				
- Author:	 	HKP																	
- Date:		19-July-2012															
- last edit:	VER 0.0.4															
-==============================================================================</Comment>
-      <BitSize>8704</BitSize>
-      <SubItem>
-        <Name>Axis</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enable</Name>
-        <Type>BOOL</Type>
-        <Comment> switch to activate backlash compensation </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Backlash</Name>
-        <Type>LREAL</Type>
-        <Comment> signed backlash value [mm] (when using default value the internal nc backlash value will be read by ADS and used in this FB) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>1E+307</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CompensationInPositiveDirection</Name>
-        <Type>BOOL</Type>
-        <Comment> compensation is just working in the selected working direction </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Ramp</Name>
-        <Type>LREAL</Type>
-        <Comment> velocity limit for feeded backlash compensation (constant velocity and linear position sub profile for backlash compensation) [mm/s] (default:=0.0) </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>DisableMode</Name>
-        <Type Namespace="Tc2_MC2">E_DisableMode</Type>
-        <Comment> disable mode defines whow to react in case of disabling: (0)=HOLD, (1)=RESET, ... </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Options</Name>
-        <Type Namespace="Tc2_MC2">ST_BacklashCompensationOptions</Type>
-        <Comment> optional parameters (NOT USED YET) </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Enabled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>344</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>352</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>360</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CurrentBacklash</Name>
-        <Type>LREAL</Type>
-        <Comment> current actual backlash value [mm] </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Limiting</Name>
-        <Type>BOOL</Type>
-        <Comment> function block is currently limiting the Backlash Correction </Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>InternalEnable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>state</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>528</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>GetThisTaskIndex</Name>
-        <Type Namespace="Tc2_System">GETCURTASKINDEX</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CycleTime</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbCalcBacklashCorrection</Name>
-        <Type Namespace="Tc2_MC2">_FB_PositionCorrectionTableLookup</Type>
-        <BitSize>1472</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbFeedBacklashCorrection</Name>
-        <Type Namespace="Tc2_MC2">MC_PositionCorrectionLimiter</Type>
-        <BitSize>1280</BitSize>
-        <BitOffs>2240</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>CalcBacklashCorrOut</Name>
-        <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>3520</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>FeedBacklashCorrOut</Name>
-        <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>3616</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ReadParameter</Name>
-        <Type Namespace="Tc2_MC2">MC_ReadParameter</Type>
-        <BitSize>4288</BitSize>
-        <BitOffs>3712</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iBacklash</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8000</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InternalAcceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8064</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InternalBacklashValue</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>InternalLimitingActive</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>stPosCompParameter</Name>
-        <Type Namespace="Tc2_MC2">ST_PositionCompensationTableParameter</Type>
-        <BitSize>192</BitSize>
-        <BitOffs>8256</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.MinPosition</Name>
-            <Value>-1000000000000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.MaxPosition</Name>
-            <Value>1000000000000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.NoOfTableElements</Name>
-            <Value>2</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.Direction</Name>
-            <Value>3</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>stPosCompTable</Name>
-        <Type Namespace="Tc2_MC2">ST_PositionCompensationTableElement</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>2</Elements>
-        </ArrayInfo>
-        <BitSize>256</BitSize>
-        <BitOffs>8448</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>[0].Position</Name>
-            <Value>-1000000000000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[0].Compensation</Name>
-            <Value>0</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[1].Position</Name>
-            <Value>1000000000000</Value>
-          </SubItem>
-          <SubItem>
-            <Name>[1].Compensation</Name>
-            <Value>0</Value>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionBacklashCompensation</Name>
-      <BitSize>8960</BitSize>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bHoming</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bMoving</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bError</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbBacklashCompensation</Name>
-        <Type Namespace="Tc2_MC2">MC_BacklashCompensation</Type>
-        <BitSize>8704</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fPrevCompensation</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>8832</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bBacklashCompEnable</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>8896</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="lcls_twincat_motion">FB_SetEnables</Name>
       <BitSize>64</BitSize>
       <SubItem>
@@ -39537,7 +37175,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_MotionStage</Name>
-      <BitSize>308416</BitSize>
+      <BitSize>299392</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
@@ -39575,136 +37213,124 @@ External Setpoint Generation:
         <BitOffs>213376</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>fbBacklashCompensation</Name>
-        <Type Namespace="lcls_twincat_motion">FB_MotionBacklashCompensation</Type>
-        <BitSize>8960</BitSize>
-        <BitOffs>296512</BitOffs>
-      </SubItem>
-      <SubItem>
         <Name>bExecute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>305472</BitOffs>
+        <BitOffs>296512</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecMove</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>305480</BitOffs>
+        <BitOffs>296520</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecHome</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>305488</BitOffs>
+        <BitOffs>296528</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bFwdHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>305496</BitOffs>
+        <BitOffs>296536</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bBwdHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>305504</BitOffs>
+        <BitOffs>296544</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftExec</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>305536</BitOffs>
+        <BitOffs>296576</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>305600</BitOffs>
+        <BitOffs>296640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtUserExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>305664</BitOffs>
+        <BitOffs>296704</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtTarget</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>305728</BitOffs>
+        <BitOffs>296768</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtHomed</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>305792</BitOffs>
+        <BitOffs>296832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSetEnables</Name>
         <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
         <BitSize>64</BitSize>
-        <BitOffs>305856</BitOffs>
+        <BitOffs>296896</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bPosGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>305920</BitOffs>
+        <BitOffs>296960</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bNegGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>305928</BitOffs>
+        <BitOffs>296968</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbEncoderValue</Name>
         <Type Namespace="lcls_twincat_motion">FB_EncoderValue</Type>
         <BitSize>64</BitSize>
-        <BitOffs>305952</BitOffs>
+        <BitOffs>296992</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbNCParams</Name>
         <Type Namespace="lcls_twincat_motion">FB_MotionStageNCParams</Type>
         <BitSize>2112</BitSize>
-        <BitOffs>306048</BitOffs>
+        <BitOffs>297088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bNewMoveReq</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>308160</BitOffs>
+        <BitOffs>299200</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bPrepareDisable</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>308168</BitOffs>
+        <BitOffs>299208</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bMoveCmd</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>308176</BitOffs>
+        <BitOffs>299216</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtMoveCmdShortcut</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>308192</BitOffs>
+        <BitOffs>299232</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtHomeCmdShortcut</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>308256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>rtEnableMode</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>308320</BitOffs>
+        <BitOffs>299296</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -40296,7 +37922,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_MotionVirtualFrame</Name>
+      <Name>FB_MotionVirtualFrame</Name>
       <BitSize>8000</BitSize>
       <SubItem>
         <Name>stMotionStageRx</Name>
@@ -40635,7 +38261,7 @@ External Setpoint Generation:
         <Parameter>
           <Name>stMotionStage</Name>
           <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-          <BitSize>26176</BitSize>
+          <BitSize>25984</BitSize>
         </Parameter>
         <Parameter>
           <Name>fActPos</Name>
@@ -40772,17 +38398,17 @@ External Setpoint Generation:
         <Parameter>
           <Name>stMotionStageX</Name>
           <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-          <BitSize>26176</BitSize>
+          <BitSize>25984</BitSize>
         </Parameter>
         <Parameter>
           <Name>stMotionStageY</Name>
           <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-          <BitSize>26176</BitSize>
+          <BitSize>25984</BitSize>
         </Parameter>
         <Parameter>
           <Name>stMotionStageZ</Name>
           <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-          <BitSize>26176</BitSize>
+          <BitSize>25984</BitSize>
         </Parameter>
         <Parameter>
           <Name>fbActPosVec3</Name>
@@ -40867,215 +38493,6 @@ External Setpoint Generation:
           <Type>LREAL</Type>
           <BitSize>64</BitSize>
         </Local>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>I_EPSSamplePaddleGasNeedle</Name>
-      <BitSize>32</BitSize>
-      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
-      <Method>
-        <Name>CheckAndActivateIfRequired</Name>
-        <Parameter>
-          <Name>StageZSamplePaddle</Name>
-          <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>StageZGasNeedle</Name>
-          <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_EPS</Name>
-      <BitSize>64</BitSize>
-      <SubItem>
-        <Name>eps</Name>
-        <Type Namespace="LCLS_General" ReferenceTo="true">DUT_EPS</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Method>
-        <Name>setBit</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nBits</Name>
-          <Type>BYTE</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>bValue</Name>
-          <Type>BOOL</Type>
-          <BitSize>8</BitSize>
-        </Parameter>
-        <Local>
-          <Name>nMask</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>nBitValue</Name>
-          <Type>UDINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-      </Method>
-      <Method>
-        <Name>setMessage</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>message</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>setDescription</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>desciption</Name>
-          <Type>STRING(80)</Type>
-          <BitSize>648</BitSize>
-        </Parameter>
-      </Method>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name>FB_EPSSamplePaddleGasNeedle</Name>
-      <BitSize>448</BitSize>
-      <Implements>I_EPSSamplePaddleGasNeedle</Implements>
-      <SubItem>
-        <Name>fbEPSSamplePaddleForwardZ</Name>
-        <Type Namespace="LCLS_General">FB_EPS</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbEPSSamplePaddleBackwardZ</Name>
-        <Type Namespace="LCLS_General">FB_EPS</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbEPSGasNeedleForwardZ</Name>
-        <Type Namespace="LCLS_General">FB_EPS</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbEPSGasNeedleBackwardZ</Name>
-        <Type Namespace="LCLS_General">FB_EPS</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSamplePaddleZOut</Name>
-        <Type>LREAL</Type>
-        <Comment> Greater than this number is out</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>100</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fGasNeedleZOut</Name>
-        <Type>LREAL</Type>
-        <Comment> Less than this number is out</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>85</Value>
-        </Default>
-      </SubItem>
-      <Method>
-        <Name>PreventSamplePaddleZFromMovingIn</Name>
-      </Method>
-      <Method>
-        <Name>AllowSamplePaddleZToMoveIn</Name>
-      </Method>
-      <Method>
-        <Name>AllowGasNeedleZToMoveIn</Name>
-      </Method>
-      <Method>
-        <Name>SamplePaddleZIsOut</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>StageZSamplePaddle</Name>
-          <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-          <BitSize>26176</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>GasNeedleZIsOut</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>StageZGasNeedle</Name>
-          <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
-          <BitSize>26176</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>CheckAndActivateIfRequired</Name>
-        <Parameter>
-          <Name>StageZSamplePaddle</Name>
-          <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-        <Parameter>
-          <Name>StageZGasNeedle</Name>
-          <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-          <BitSize>32</BitSize>
-          <Properties>
-            <Property>
-              <Name>ItemType</Name>
-              <Value>InOut</Value>
-            </Property>
-          </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>PreventGasNeedleZFromMovingIn</Name>
       </Method>
       <Properties>
         <Property>
@@ -42436,6 +39853,215 @@ External Setpoint Generation:
         <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
       </Hides>
     </DataType>
+    <DataType>
+      <Name>I_EPSSamplePaddleGasNeedle</Name>
+      <BitSize>32</BitSize>
+      <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <Method>
+        <Name>CheckAndActivateIfRequired</Name>
+        <Parameter>
+          <Name>StageZSamplePaddle</Name>
+          <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>StageZGasNeedle</Name>
+          <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_EPS</Name>
+      <BitSize>64</BitSize>
+      <SubItem>
+        <Name>eps</Name>
+        <Type Namespace="LCLS_General" ReferenceTo="true">DUT_EPS</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Method>
+        <Name>setBit</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nBits</Name>
+          <Type>BYTE</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>bValue</Name>
+          <Type>BOOL</Type>
+          <BitSize>8</BitSize>
+        </Parameter>
+        <Local>
+          <Name>nMask</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+        <Local>
+          <Name>nBitValue</Name>
+          <Type>UDINT</Type>
+          <BitSize>32</BitSize>
+        </Local>
+      </Method>
+      <Method>
+        <Name>setMessage</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>message</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>setDescription</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>desciption</Name>
+          <Type>STRING(80)</Type>
+          <BitSize>648</BitSize>
+        </Parameter>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>FB_EPSSamplePaddleGasNeedle</Name>
+      <BitSize>448</BitSize>
+      <Implements>I_EPSSamplePaddleGasNeedle</Implements>
+      <SubItem>
+        <Name>fbEPSSamplePaddleForwardZ</Name>
+        <Type Namespace="LCLS_General">FB_EPS</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbEPSSamplePaddleBackwardZ</Name>
+        <Type Namespace="LCLS_General">FB_EPS</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbEPSGasNeedleForwardZ</Name>
+        <Type Namespace="LCLS_General">FB_EPS</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbEPSGasNeedleBackwardZ</Name>
+        <Type Namespace="LCLS_General">FB_EPS</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSamplePaddleZOut</Name>
+        <Type>LREAL</Type>
+        <Comment> Greater than this number is out</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>100</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fGasNeedleZOut</Name>
+        <Type>LREAL</Type>
+        <Comment> Less than this number is out</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>85</Value>
+        </Default>
+      </SubItem>
+      <Method>
+        <Name>PreventSamplePaddleZFromMovingIn</Name>
+      </Method>
+      <Method>
+        <Name>AllowSamplePaddleZToMoveIn</Name>
+      </Method>
+      <Method>
+        <Name>AllowGasNeedleZToMoveIn</Name>
+      </Method>
+      <Method>
+        <Name>SamplePaddleZIsOut</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>StageZSamplePaddle</Name>
+          <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+          <BitSize>25984</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>GasNeedleZIsOut</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>StageZGasNeedle</Name>
+          <Type Namespace="lcls_twincat_motion">ST_MotionStage</Type>
+          <BitSize>25984</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>CheckAndActivateIfRequired</Name>
+        <Parameter>
+          <Name>StageZSamplePaddle</Name>
+          <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+        <Parameter>
+          <Name>StageZGasNeedle</Name>
+          <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+          <BitSize>32</BitSize>
+          <Properties>
+            <Property>
+              <Name>ItemType</Name>
+              <Value>InOut</Value>
+            </Property>
+          </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>PreventGasNeedleZFromMovingIn</Name>
+      </Method>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{661B40ED-AEC3-4C67-9C61-2B71CC714620}" TcSmClass="TComPlcObjDef">
@@ -42457,7 +40083,7 @@ External Setpoint Generation:
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>80543744</ByteSize>
+          <ByteSize>81002496</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -42468,7 +40094,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635683584</BitOffs>
+            <BitOffs>635681856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -42481,7 +40107,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635691584</BitOffs>
+            <BitOffs>635689856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -42494,7 +40120,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635691592</BitOffs>
+            <BitOffs>635689864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -42507,7 +40133,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635691600</BitOffs>
+            <BitOffs>635689872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -42530,7 +40156,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635691616</BitOffs>
+            <BitOffs>635689888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -42543,7 +40169,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635691648</BitOffs>
+            <BitOffs>635689920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -42556,7 +40182,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635691712</BitOffs>
+            <BitOffs>635689984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -42569,7 +40195,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635691728</BitOffs>
+            <BitOffs>635690000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderDINT</Name>
@@ -42582,7 +40208,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635691744</BitOffs>
+            <BitOffs>635690016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
@@ -42594,7 +40220,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635709760</BitOffs>
+            <BitOffs>635707840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -42607,7 +40233,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635717760</BitOffs>
+            <BitOffs>635715840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -42620,7 +40246,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635717768</BitOffs>
+            <BitOffs>635715848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -42633,7 +40259,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635717776</BitOffs>
+            <BitOffs>635715856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -42656,7 +40282,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635717792</BitOffs>
+            <BitOffs>635715872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -42669,7 +40295,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635717824</BitOffs>
+            <BitOffs>635715904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -42682,7 +40308,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635717888</BitOffs>
+            <BitOffs>635715968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -42695,7 +40321,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635717904</BitOffs>
+            <BitOffs>635715984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderDINT</Name>
@@ -42708,7 +40334,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635717920</BitOffs>
+            <BitOffs>635716000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
@@ -42720,7 +40346,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635735936</BitOffs>
+            <BitOffs>635733824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -42733,7 +40359,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635743936</BitOffs>
+            <BitOffs>635741824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -42746,7 +40372,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635743944</BitOffs>
+            <BitOffs>635741832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -42759,7 +40385,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635743952</BitOffs>
+            <BitOffs>635741840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -42782,7 +40408,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635743968</BitOffs>
+            <BitOffs>635741856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -42795,7 +40421,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635744000</BitOffs>
+            <BitOffs>635741888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -42808,7 +40434,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635744064</BitOffs>
+            <BitOffs>635741952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -42821,7 +40447,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635744080</BitOffs>
+            <BitOffs>635741968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderDINT</Name>
@@ -42834,7 +40460,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635744096</BitOffs>
+            <BitOffs>635741984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
@@ -42846,7 +40472,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635762112</BitOffs>
+            <BitOffs>635759808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -42859,7 +40485,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635770112</BitOffs>
+            <BitOffs>635767808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -42872,7 +40498,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635770120</BitOffs>
+            <BitOffs>635767816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -42885,7 +40511,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635770128</BitOffs>
+            <BitOffs>635767824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -42908,7 +40534,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635770144</BitOffs>
+            <BitOffs>635767840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -42921,7 +40547,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635770176</BitOffs>
+            <BitOffs>635767872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -42934,7 +40560,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635770240</BitOffs>
+            <BitOffs>635767936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -42947,7 +40573,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635770256</BitOffs>
+            <BitOffs>635767952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderDINT</Name>
@@ -42960,7 +40586,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635770272</BitOffs>
+            <BitOffs>635767968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
@@ -42972,7 +40598,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635788288</BitOffs>
+            <BitOffs>635785792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -42985,7 +40611,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635796288</BitOffs>
+            <BitOffs>635793792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -42998,7 +40624,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635796296</BitOffs>
+            <BitOffs>635793800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -43011,7 +40637,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635796304</BitOffs>
+            <BitOffs>635793808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -43034,7 +40660,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635796320</BitOffs>
+            <BitOffs>635793824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -43047,7 +40673,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635796352</BitOffs>
+            <BitOffs>635793856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -43060,7 +40686,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635796416</BitOffs>
+            <BitOffs>635793920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -43073,7 +40699,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635796432</BitOffs>
+            <BitOffs>635793936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderDINT</Name>
@@ -43086,7 +40712,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635796448</BitOffs>
+            <BitOffs>635793952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
@@ -43098,7 +40724,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635814464</BitOffs>
+            <BitOffs>635811776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -43111,7 +40737,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635822464</BitOffs>
+            <BitOffs>635819776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -43124,7 +40750,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635822472</BitOffs>
+            <BitOffs>635819784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -43137,7 +40763,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635822480</BitOffs>
+            <BitOffs>635819792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -43160,7 +40786,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635822496</BitOffs>
+            <BitOffs>635819808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -43173,7 +40799,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635822528</BitOffs>
+            <BitOffs>635819840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -43186,7 +40812,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635822592</BitOffs>
+            <BitOffs>635819904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -43199,7 +40825,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635822608</BitOffs>
+            <BitOffs>635819920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderDINT</Name>
@@ -43212,7 +40838,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635822624</BitOffs>
+            <BitOffs>635819936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.NcToPlc</Name>
@@ -43224,7 +40850,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635840640</BitOffs>
+            <BitOffs>635837760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitForwardEnable</Name>
@@ -43237,7 +40863,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635848640</BitOffs>
+            <BitOffs>635845760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bLimitBackwardEnable</Name>
@@ -43250,7 +40876,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635848648</BitOffs>
+            <BitOffs>635845768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHome</Name>
@@ -43263,7 +40889,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635848656</BitOffs>
+            <BitOffs>635845776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bHardwareEnable</Name>
@@ -43286,7 +40912,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635848672</BitOffs>
+            <BitOffs>635845792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderULINT</Name>
@@ -43299,7 +40925,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635848704</BitOffs>
+            <BitOffs>635845824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderUINT</Name>
@@ -43312,7 +40938,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635848768</BitOffs>
+            <BitOffs>635845888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderINT</Name>
@@ -43325,7 +40951,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635848784</BitOffs>
+            <BitOffs>635845904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.nRawEncoderDINT</Name>
@@ -43338,7 +40964,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635848800</BitOffs>
+            <BitOffs>635845920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.NcToPlc</Name>
@@ -43350,7 +40976,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635866816</BitOffs>
+            <BitOffs>635863744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitForwardEnable</Name>
@@ -43363,7 +40989,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635874816</BitOffs>
+            <BitOffs>635871744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bLimitBackwardEnable</Name>
@@ -43376,7 +41002,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635874824</BitOffs>
+            <BitOffs>635871752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHome</Name>
@@ -43389,7 +41015,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635874832</BitOffs>
+            <BitOffs>635871760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bHardwareEnable</Name>
@@ -43412,7 +41038,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635874848</BitOffs>
+            <BitOffs>635871776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderULINT</Name>
@@ -43425,7 +41051,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635874880</BitOffs>
+            <BitOffs>635871808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderUINT</Name>
@@ -43438,7 +41064,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635874944</BitOffs>
+            <BitOffs>635871872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderINT</Name>
@@ -43451,7 +41077,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635874960</BitOffs>
+            <BitOffs>635871888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.nRawEncoderDINT</Name>
@@ -43464,7 +41090,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635874976</BitOffs>
+            <BitOffs>635871904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.NcToPlc</Name>
@@ -43476,7 +41102,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635892992</BitOffs>
+            <BitOffs>635889728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitForwardEnable</Name>
@@ -43489,7 +41115,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635900992</BitOffs>
+            <BitOffs>635897728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bLimitBackwardEnable</Name>
@@ -43502,7 +41128,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635901000</BitOffs>
+            <BitOffs>635897736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHome</Name>
@@ -43515,7 +41141,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635901008</BitOffs>
+            <BitOffs>635897744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bHardwareEnable</Name>
@@ -43538,7 +41164,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635901024</BitOffs>
+            <BitOffs>635897760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderULINT</Name>
@@ -43551,7 +41177,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635901056</BitOffs>
+            <BitOffs>635897792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderUINT</Name>
@@ -43564,7 +41190,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635901120</BitOffs>
+            <BitOffs>635897856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderINT</Name>
@@ -43577,7 +41203,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635901136</BitOffs>
+            <BitOffs>635897872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.nRawEncoderDINT</Name>
@@ -43590,7 +41216,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635901152</BitOffs>
+            <BitOffs>635897888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43602,7 +41228,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635920576</BitOffs>
+            <BitOffs>635917120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43614,7 +41240,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636228992</BitOffs>
+            <BitOffs>636216512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43626,7 +41252,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636537408</BitOffs>
+            <BitOffs>636515904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43638,7 +41264,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636845824</BitOffs>
+            <BitOffs>636815296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43650,7 +41276,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637154240</BitOffs>
+            <BitOffs>637114688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM6.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43662,7 +41288,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637462656</BitOffs>
+            <BitOffs>637414080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM7.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43674,7 +41300,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637771072</BitOffs>
+            <BitOffs>637713472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM8.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43686,7 +41312,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638079488</BitOffs>
+            <BitOffs>638012864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM9.fbDriveVirtual.MasterAxis.NcToPlc</Name>
@@ -43698,14 +41324,14 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>638387904</BitOffs>
+            <BitOffs>638312256</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>80543744</ByteSize>
+          <ByteSize>81002496</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -43716,7 +41342,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635682560</BitOffs>
+            <BitOffs>635680832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -43729,7 +41355,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635691608</BitOffs>
+            <BitOffs>635689880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -43741,7 +41367,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635708736</BitOffs>
+            <BitOffs>635706816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -43754,7 +41380,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635717784</BitOffs>
+            <BitOffs>635715864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -43766,7 +41392,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635734912</BitOffs>
+            <BitOffs>635732800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -43779,7 +41405,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635743960</BitOffs>
+            <BitOffs>635741848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -43791,7 +41417,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635761088</BitOffs>
+            <BitOffs>635758784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -43804,7 +41430,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635770136</BitOffs>
+            <BitOffs>635767832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -43816,7 +41442,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635787264</BitOffs>
+            <BitOffs>635784768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -43829,7 +41455,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635796312</BitOffs>
+            <BitOffs>635793816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -43841,7 +41467,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635813440</BitOffs>
+            <BitOffs>635810752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -43854,7 +41480,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635822488</BitOffs>
+            <BitOffs>635819800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.Axis.PlcToNc</Name>
@@ -43866,7 +41492,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635839616</BitOffs>
+            <BitOffs>635836736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7.bBrakeRelease</Name>
@@ -43879,7 +41505,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635848664</BitOffs>
+            <BitOffs>635845784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.Axis.PlcToNc</Name>
@@ -43891,7 +41517,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635865792</BitOffs>
+            <BitOffs>635862720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8.bBrakeRelease</Name>
@@ -43904,7 +41530,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635874840</BitOffs>
+            <BitOffs>635871768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.Axis.PlcToNc</Name>
@@ -43916,7 +41542,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635891968</BitOffs>
+            <BitOffs>635888704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9.bBrakeRelease</Name>
@@ -43929,7 +41555,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635901016</BitOffs>
+            <BitOffs>635897752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -43941,7 +41567,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635919552</BitOffs>
+            <BitOffs>635916096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -43953,7 +41579,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636227968</BitOffs>
+            <BitOffs>636215488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -43965,7 +41591,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636536384</BitOffs>
+            <BitOffs>636514880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -43977,7 +41603,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636844800</BitOffs>
+            <BitOffs>636814272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM5.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -43989,7 +41615,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>637153216</BitOffs>
+            <BitOffs>637113664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM6.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -44001,7 +41627,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>637461632</BitOffs>
+            <BitOffs>637413056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM7.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -44013,7 +41639,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>637770048</BitOffs>
+            <BitOffs>637712448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM8.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -44025,7 +41651,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638078464</BitOffs>
+            <BitOffs>638011840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM9.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -44037,7 +41663,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638386880</BitOffs>
+            <BitOffs>638311232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nVirtualEncoderM7nm</Name>
@@ -44054,7 +41680,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638693888</BitOffs>
+            <BitOffs>638609216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nVirtualEncoderM8nm</Name>
@@ -44071,7 +41697,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638693920</BitOffs>
+            <BitOffs>638609248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nVirtualEncoderM9nm</Name>
@@ -44088,369 +41714,27 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>638693952</BitOffs>
+            <BitOffs>638609280</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>80543744</ByteSize>
+          <ByteSize>81002496</ByteSize>
           <Symbol>
-            <Name>DefaultGlobals.stSys</Name>
-            <Comment>Included for you</Comment>
-            <BitSize>40</BitSize>
-            <BaseType Namespace="LCLS_General">ST_System</BaseType>
+            <Name>GVL_Constants.PI</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>3.14159265358979</Value>
+            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
             <BitOffs>4096000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.bTrickleTripped</Name>
-            <Comment> Global trickle trip flag</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
-        io: i
-        field: DESC Tripped by overall log count
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GeneralConstants.MAX_STATES</Name>
-            <Comment> 16 including "Unknown" is the max for an EPICS MBBI/MBBO
- This is the max number of user-defined states (OUT, TARGET1, YAG...)
- You can make this smaller if you want to use less memory in your program in exchange for limiting your max state count
- You can make this larger if you want to use states-based FBs sized beyond the EPICS enum limit</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>15</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>DefaultGlobals.fTimeStamp</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096064</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.cLogHost</Name>
-            <Comment>
-    Using the IP address directly avoids DNS configuration issues.
-    While we may want to address this in the future, for now the static IP
-    will suffice:
-
-    $ nslookup ctl-logsrv01
-    Name:   ctl-logsrv01.pcdsn
-    Address: 172.21.32.36
-    </Comment>
-            <BitSize>128</BitSize>
-            <BaseType>STRING(15)</BaseType>
-            <Default>
-              <String>172.21.32.36</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:LogHost
-        io: io
-        field: DESC The log host IP address
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.iLogPort</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>54321</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:LogPort
-        io: io
-        field: DESC The log host UDP port
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.sIpTidbit</Name>
-            <BitSize>56</BitSize>
-            <BaseType>STRING(6)</BaseType>
-            <Default>
-              <String>172.21</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_LOADED</Name>
-            <Comment> Retain data loaded </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096328</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
-            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>5</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nLocalTripThreshold</Name>
-            <Comment> Minimum time between log messages</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096352</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
-            <Comment> Default trickle trip, activated by global threshold</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTrickleTripTime</Name>
-            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTripResetPeriod</Name>
-            <Comment> Default time for CB auto-reset</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>600000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.sPlcHostname</Name>
-            <BitSize>648</BitSize>
-            <BaseType>STRING(80)</BaseType>
-            <Default>
-              <String>unknown</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
-            <Comment> Retain data is invalid </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4097128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_LOGGER</Name>
-            <Comment> Logger </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4097136</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
-            <Comment> Ref: https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/TcPlcLibTcpIp_FB_SocketUdpSendTo.htm
-        TODO: Activate the "Replace constants" option in the
-        TwinCAT PLC Control-&gt;"Project-&gt;Options...-&gt;Build" dialog window.
-    </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>10000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>analysis</Name>
-                <Value>-33</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4097152</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nGlobAccEvents</Name>
-            <Comment> Global log message count</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:LogMessageCount
-        io: i
-        field: DESC Total log messages on the last cycle
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4097184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.fbRootLogger</Name>
-            <Comment>Instantiated here to be used everywhere</Comment>
-            <BitSize>81984</BitSize>
-            <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4097216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_Tc2_EtherCAT</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>3</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>21</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>3.3.21.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4179200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Standard</Name>
@@ -44490,7 +41774,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4179488</BitOffs>
+            <BitOffs>4096064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_System</Name>
@@ -44530,7 +41814,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4179776</BitOffs>
+            <BitOffs>4096352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_LOGGER</Name>
+            <Comment> Logger </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4096640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
@@ -44545,7 +41844,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180064</BitOffs>
+            <BitOffs>4096656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_RTIME</Name>
@@ -44560,7 +41859,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180080</BitOffs>
+            <BitOffs>4096672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_IO</Name>
@@ -44575,7 +41874,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180096</BitOffs>
+            <BitOffs>4096688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NC</Name>
@@ -44589,7 +41888,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180112</BitOffs>
+            <BitOffs>4096704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSAF</Name>
@@ -44603,7 +41902,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180128</BitOffs>
+            <BitOffs>4096720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSVB</Name>
@@ -44617,7 +41916,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180144</BitOffs>
+            <BitOffs>4096736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_ISG</Name>
@@ -44631,7 +41930,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180160</BitOffs>
+            <BitOffs>4096752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CNC</Name>
@@ -44645,7 +41944,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180176</BitOffs>
+            <BitOffs>4096768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_LINE</Name>
@@ -44659,7 +41958,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180192</BitOffs>
+            <BitOffs>4096784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC</Name>
@@ -44673,7 +41972,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180208</BitOffs>
+            <BitOffs>4096800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS1</Name>
@@ -44688,7 +41987,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180224</BitOffs>
+            <BitOffs>4096816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS2</Name>
@@ -44703,7 +42002,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180240</BitOffs>
+            <BitOffs>4096832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS3</Name>
@@ -44718,7 +42017,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180256</BitOffs>
+            <BitOffs>4096848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS4</Name>
@@ -44733,7 +42032,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180272</BitOffs>
+            <BitOffs>4096864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAM</Name>
@@ -44747,7 +42046,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180288</BitOffs>
+            <BitOffs>4096880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAMTOOL</Name>
@@ -44762,7 +42061,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180304</BitOffs>
+            <BitOffs>4096896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
@@ -44777,7 +42076,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180320</BitOffs>
+            <BitOffs>4096912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SCOPESERVER</Name>
@@ -44792,7 +42091,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180336</BitOffs>
+            <BitOffs>4096928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INVALID</Name>
@@ -44807,7 +42106,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180352</BitOffs>
+            <BitOffs>4096944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_IDLE</Name>
@@ -44821,7 +42120,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180368</BitOffs>
+            <BitOffs>4096960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESET</Name>
@@ -44835,7 +42134,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180384</BitOffs>
+            <BitOffs>4096976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INIT</Name>
@@ -44849,7 +42148,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180400</BitOffs>
+            <BitOffs>4096992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_START</Name>
@@ -44863,7 +42162,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180416</BitOffs>
+            <BitOffs>4097008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RUN</Name>
@@ -44877,7 +42176,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180432</BitOffs>
+            <BitOffs>4097024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOP</Name>
@@ -44891,7 +42190,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180448</BitOffs>
+            <BitOffs>4097040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SAVECFG</Name>
@@ -44905,7 +42204,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180464</BitOffs>
+            <BitOffs>4097056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_LOADCFG</Name>
@@ -44919,7 +42218,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180480</BitOffs>
+            <BitOffs>4097072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERFAILURE</Name>
@@ -44933,7 +42232,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180496</BitOffs>
+            <BitOffs>4097088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERGOOD</Name>
@@ -44947,7 +42246,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180512</BitOffs>
+            <BitOffs>4097104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_ERROR</Name>
@@ -44961,7 +42260,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180528</BitOffs>
+            <BitOffs>4097120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SHUTDOWN</Name>
@@ -44975,7 +42274,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180544</BitOffs>
+            <BitOffs>4097136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SUSPEND</Name>
@@ -44989,7 +42288,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180560</BitOffs>
+            <BitOffs>4097152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESUME</Name>
@@ -45003,7 +42302,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180576</BitOffs>
+            <BitOffs>4097168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_CONFIG</Name>
@@ -45018,7 +42317,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180592</BitOffs>
+            <BitOffs>4097184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RECONFIG</Name>
@@ -45033,7 +42332,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180608</BitOffs>
+            <BitOffs>4097200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOPPING</Name>
@@ -45047,7 +42346,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180624</BitOffs>
+            <BitOffs>4097216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INCOMPATIBLE</Name>
@@ -45061,7 +42360,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180640</BitOffs>
+            <BitOffs>4097232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_EXCEPTION</Name>
@@ -45075,7 +42374,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180656</BitOffs>
+            <BitOffs>4097248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_MAXSTATES</Name>
@@ -45090,36 +42389,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180672</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_REQUESTED</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4180688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_LOADED</Name>
-            <Comment> Persistent data loaded </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4180696</BitOffs>
+            <BitOffs>4097264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMTAB</Name>
@@ -45134,7 +42404,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180704</BitOffs>
+            <BitOffs>4097280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMNAME</Name>
@@ -45149,7 +42419,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180736</BitOffs>
+            <BitOffs>4097312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMVAL</Name>
@@ -45164,7 +42434,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180768</BitOffs>
+            <BitOffs>4097344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_HNDBYNAME</Name>
@@ -45178,7 +42448,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180800</BitOffs>
+            <BitOffs>4097376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VALBYNAME</Name>
@@ -45192,7 +42462,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180832</BitOffs>
+            <BitOffs>4097408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VALBYHND</Name>
@@ -45206,7 +42476,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180864</BitOffs>
+            <BitOffs>4097440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_RELEASEHND</Name>
@@ -45220,7 +42490,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180896</BitOffs>
+            <BitOffs>4097472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAME</Name>
@@ -45234,7 +42504,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180928</BitOffs>
+            <BitOffs>4097504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_VERSION</Name>
@@ -45248,7 +42518,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180960</BitOffs>
+            <BitOffs>4097536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAMEEX</Name>
@@ -45262,7 +42532,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4180992</BitOffs>
+            <BitOffs>4097568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_DOWNLOAD</Name>
@@ -45276,7 +42546,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181024</BitOffs>
+            <BitOffs>4097600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_UPLOAD</Name>
@@ -45290,7 +42560,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181056</BitOffs>
+            <BitOffs>4097632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYM_UPLOADINFO</Name>
@@ -45304,7 +42574,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181088</BitOffs>
+            <BitOffs>4097664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_SYMNOTE</Name>
@@ -45319,7 +42589,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181120</BitOffs>
+            <BitOffs>4097696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIB</Name>
@@ -45334,7 +42604,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181152</BitOffs>
+            <BitOffs>4097728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIX</Name>
@@ -45349,7 +42619,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181184</BitOffs>
+            <BitOffs>4097760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RISIZE</Name>
@@ -45364,7 +42634,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181216</BitOffs>
+            <BitOffs>4097792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOB</Name>
@@ -45379,7 +42649,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181248</BitOffs>
+            <BitOffs>4097824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOX</Name>
@@ -45394,7 +42664,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181280</BitOffs>
+            <BitOffs>4097856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_ROSIZE</Name>
@@ -45409,7 +42679,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181312</BitOffs>
+            <BitOffs>4097888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARI</Name>
@@ -45424,7 +42694,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181344</BitOffs>
+            <BitOffs>4097920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARO</Name>
@@ -45439,7 +42709,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181376</BitOffs>
+            <BitOffs>4097952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIOB</Name>
@@ -45454,7 +42724,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181408</BitOffs>
+            <BitOffs>4097984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIGRP_DEVICE_DATA</Name>
@@ -45469,7 +42739,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181440</BitOffs>
+            <BitOffs>4098016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIOFFS_DEVDATA_ADSSTATE</Name>
@@ -45484,7 +42754,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181472</BitOffs>
+            <BitOffs>4098048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSIOFFS_DEVDATA_DEVSTATE</Name>
@@ -45499,7 +42769,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181504</BitOffs>
+            <BitOffs>4098080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENCREATE</Name>
@@ -45514,7 +42784,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181536</BitOffs>
+            <BitOffs>4098112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENREAD</Name>
@@ -45529,7 +42799,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181568</BitOffs>
+            <BitOffs>4098144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_OPENWRITE</Name>
@@ -45544,7 +42814,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181600</BitOffs>
+            <BitOffs>4098176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CREATEFILE</Name>
@@ -45559,7 +42829,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181632</BitOffs>
+            <BitOffs>4098208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CLOSEHANDLE</Name>
@@ -45574,7 +42844,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181664</BitOffs>
+            <BitOffs>4098240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FOPEN</Name>
@@ -45588,7 +42858,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181696</BitOffs>
+            <BitOffs>4098272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FCLOSE</Name>
@@ -45602,7 +42872,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181728</BitOffs>
+            <BitOffs>4098304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FREAD</Name>
@@ -45616,7 +42886,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181760</BitOffs>
+            <BitOffs>4098336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FWRITE</Name>
@@ -45630,7 +42900,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181792</BitOffs>
+            <BitOffs>4098368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FSEEK</Name>
@@ -45644,7 +42914,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181824</BitOffs>
+            <BitOffs>4098400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FTELL</Name>
@@ -45658,7 +42928,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181856</BitOffs>
+            <BitOffs>4098432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FGETS</Name>
@@ -45672,7 +42942,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181888</BitOffs>
+            <BitOffs>4098464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FPUTS</Name>
@@ -45686,7 +42956,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181920</BitOffs>
+            <BitOffs>4098496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FSCANF</Name>
@@ -45700,7 +42970,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181952</BitOffs>
+            <BitOffs>4098528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FPRINTF</Name>
@@ -45714,7 +42984,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4181984</BitOffs>
+            <BitOffs>4098560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FEOF</Name>
@@ -45728,7 +42998,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182016</BitOffs>
+            <BitOffs>4098592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FDELETE</Name>
@@ -45742,7 +43012,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182048</BitOffs>
+            <BitOffs>4098624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FRENAME</Name>
@@ -45756,7 +43026,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182080</BitOffs>
+            <BitOffs>4098656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_MKDIR</Name>
@@ -45770,7 +43040,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182112</BitOffs>
+            <BitOffs>4098688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_RMDIR</Name>
@@ -45784,7 +43054,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182144</BitOffs>
+            <BitOffs>4098720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
@@ -45798,7 +43068,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182176</BitOffs>
+            <BitOffs>4098752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
@@ -45812,7 +43082,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182208</BitOffs>
+            <BitOffs>4098784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_TIMESERVICES</Name>
@@ -45826,7 +43096,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182240</BitOffs>
+            <BitOffs>4098816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_STARTPROCESS</Name>
@@ -45840,7 +43110,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182272</BitOffs>
+            <BitOffs>4098848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_CHANGENETID</Name>
@@ -45854,7 +43124,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182304</BitOffs>
+            <BitOffs>4098880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_DATEANDTIME</Name>
@@ -45869,7 +43139,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182336</BitOffs>
+            <BitOffs>4098912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_SYSTEMTIMES</Name>
@@ -45883,7 +43153,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182368</BitOffs>
+            <BitOffs>4098944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_RTCTIMEDIFF</Name>
@@ -45897,7 +43167,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182400</BitOffs>
+            <BitOffs>4098976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_ADJUSTTIMETORTC</Name>
@@ -45911,7 +43181,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182432</BitOffs>
+            <BitOffs>4099008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TIMESERVICE_TIMEZONINFORMATION</Name>
@@ -45925,7 +43195,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182464</BitOffs>
+            <BitOffs>4099040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
@@ -45940,7 +43210,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182496</BitOffs>
+            <BitOffs>4099072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
@@ -45955,7 +43225,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182528</BitOffs>
+            <BitOffs>4099104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
@@ -45970,7 +43240,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182560</BitOffs>
+            <BitOffs>4099136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
@@ -45985,7 +43255,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182592</BitOffs>
+            <BitOffs>4099168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
@@ -46000,7 +43270,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182624</BitOffs>
+            <BitOffs>4099200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_RESOURCE</Name>
@@ -46014,7 +43284,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182656</BitOffs>
+            <BitOffs>4099232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSLOG_MSGTYPE_STRING</Name>
@@ -46028,7 +43298,66 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182688</BitOffs>
+            <BitOffs>4099264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_LOADED</Name>
+            <Comment> Retain data loaded </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4099296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
+            <Comment> Retain data is invalid </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4099304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_REQUESTED</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4099312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_LOADED</Name>
+            <Comment> Persistent data loaded </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4099320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_INVALID</Name>
@@ -46043,7 +43372,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182720</BitOffs>
+            <BitOffs>4099328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_BSOD</Name>
@@ -46058,7 +43387,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182728</BitOffs>
+            <BitOffs>4099336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_RTVIOLATION</Name>
@@ -46073,7 +43402,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182736</BitOffs>
+            <BitOffs>4099344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.nWatchdogTime</Name>
@@ -46085,7 +43414,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182744</BitOffs>
+            <BitOffs>4099352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEREAD</Name>
@@ -46100,7 +43429,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182752</BitOffs>
+            <BitOffs>4099360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEWRITE</Name>
@@ -46115,7 +43444,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182784</BitOffs>
+            <BitOffs>4099392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEAPPEND</Name>
@@ -46130,7 +43459,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182816</BitOffs>
+            <BitOffs>4099424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEPLUS</Name>
@@ -46145,7 +43474,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182848</BitOffs>
+            <BitOffs>4099456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEBINARY</Name>
@@ -46160,7 +43489,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182880</BitOffs>
+            <BitOffs>4099488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODETEXT</Name>
@@ -46175,7 +43504,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4182912</BitOffs>
+            <BitOffs>4099520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_PRIOCLASS</Name>
@@ -46190,7 +43519,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183168</BitOffs>
+            <BitOffs>4099776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_FMTSELF</Name>
@@ -46205,7 +43534,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183184</BitOffs>
+            <BitOffs>4099792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_LOG</Name>
@@ -46220,7 +43549,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183200</BitOffs>
+            <BitOffs>4099808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_MSGBOX</Name>
@@ -46235,7 +43564,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183216</BitOffs>
+            <BitOffs>4099824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_SRCID</Name>
@@ -46250,7 +43579,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183232</BitOffs>
+            <BitOffs>4099840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_AUTOFMTALL</Name>
@@ -46264,7 +43593,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183248</BitOffs>
+            <BitOffs>4099856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_INVALID</Name>
@@ -46279,7 +43608,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183264</BitOffs>
+            <BitOffs>4099872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_SIGNALED</Name>
@@ -46294,7 +43623,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183280</BitOffs>
+            <BitOffs>4099888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESET</Name>
@@ -46309,7 +43638,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183296</BitOffs>
+            <BitOffs>4099904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_CONFIRMED</Name>
@@ -46324,7 +43653,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183312</BitOffs>
+            <BitOffs>4099920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESETCON</Name>
@@ -46339,7 +43668,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183328</BitOffs>
+            <BitOffs>4099936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_SRCNAMESIZE</Name>
@@ -46353,7 +43682,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183344</BitOffs>
+            <BitOffs>4099952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_FMTPRGSIZE</Name>
@@ -46367,7 +43696,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183360</BitOffs>
+            <BitOffs>4099968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.eWatchdogConfig</Name>
@@ -46381,7 +43710,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183376</BitOffs>
+            <BitOffs>4099984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
@@ -46396,7 +43725,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183392</BitOffs>
+            <BitOffs>4100000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.PI</Name>
@@ -46410,7 +43739,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183424</BitOffs>
+            <BitOffs>4100032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_STRING_LENGTH</Name>
@@ -46425,7 +43754,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183488</BitOffs>
+            <BitOffs>4100096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_Module</Name>
@@ -46461,7 +43790,348 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184032</BitOffs>
+            <BitOffs>4100640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4101248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4101264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4101280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
+            <Comment> TcUnit logs complete test results. These include:
+         - Number of test suites
+         - Number of tests
+         - Number of successful tests
+         - Number of failed tests
+         - Any eventual failed assertion (with the expected &amp; actual value plus an user defined message)
+       These are all printed to the ADS logger (Visual Studio error list) marked with ERROR criticality
+
+       On top of this TcUnit also reports some statistics/extended information with HINT/INFO criticality.
+       These statistics are more detailed results of the tests. This information is used when results are
+       being collected by an external software (such as TcUnit-Runner) to do for example Jenkins integration.
+       This extra information however takes time to print, so by setting the following parameter to FALSE
+       it will speed up TcUnit finishing. </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4101296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
+            <Comment> Enable (TRUE) or disable (FALSE) publishing of the xUnit Xml report </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4101304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
+            <Comment> Default reserved PLC memory buffer used for composition of the xUnit xml file (64 kb default) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>65535</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4101312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
+            <Comment> Default path and filename for the xunit testresults e.g.: for use with jenkins </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Default>
+              <String>C:\tcunit_xunit_testresults.xml</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4101344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
+            <Comment> This is the maximum number of ADS-messages that can be stored for reporting at the same time.
+       Having a size of 2000 means that it's possible to report up to ~400 test cases in one single
+       PLC cycle. Each entry consumes around 500 bytes, so with an example of a ring buffer size of
+       2000 it means that TcUnit will consume around 1 MB of router memory. </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>2000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4103392</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
+            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4103408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
+            <Comment> Whether or not the current test being called has finished running </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4103416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
+            <Comment> Time delay between a test suite is finished and the execution of the next test suite starts
+       if using RUN_IN_SEQUENCE() </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4103424</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TcUnitRunner</Name>
+            <BitSize>621827200</BitSize>
+            <BaseType Namespace="LCLS_General.TcUnit">FB_TcUnitRunner</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>4103456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
+            <Comment> Pointer to current test suite being called </Comment>
+            <BitSize>32</BitSize>
+            <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625930656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
+            <Comment> Current name of test being called </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625930688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
+            <Comment> This is a flag that indicates that the current test should be ignored, and
+       thus that all assertions under it should be ignored as well. A test can be ignored either
+       because the user has requested so, or because the test is a duplicate name </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625932736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
+            <Comment> TRUE = Enable DCF77 telegram plausibility check (two telegrams are checked), FALSE = Disable check </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625932744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
+            <Comment> The assert function block instance should be 1:1 mapped to
+       the test suite instance path. </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625932752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.TestSuiteAddresses</Name>
+            <BitSize>32000</BitSize>
+            <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>1000</Elements>
+            </ArrayInfo>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625932768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
+            <Comment> If the user is utilizing the TEST_ORDERED(), we need to keep track of which ordered test is currently running.
+       We do this by defining an array, in where we can see which current TEST_ORDERED() is the one to be handled right now.
+       The below array is only used for TEST_ORDERED()-tests.  </Comment>
+            <BitSize>16000</BitSize>
+            <BaseType>UINT</BaseType>
+            <ArrayInfo>
+              <LBound>1</LBound>
+              <Elements>1000</Elements>
+            </ArrayInfo>
+            <Properties>
+              <Property>
+                <Name>LowerBorder</Name>
+                <Value>1</Value>
+              </Property>
+              <Property>
+                <Name>UpperBorder</Name>
+                <Value>100</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625964768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TcUnit.AdsMessageQueue</Name>
+            <Comment> Buffered ADS message queue for output to the error list </Comment>
+            <BitSize>8320864</BitSize>
+            <BaseType Namespace="LCLS_General.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>625980768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_TcUnit</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>2</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>1.2.0.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634301632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Utilities</Name>
@@ -46501,7 +44171,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184640</BitOffs>
+            <BitOffs>634301920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_AVERAGE_MEASURES</Name>
@@ -46524,7 +44194,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184928</BitOffs>
+            <BitOffs>634302208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
@@ -46539,7 +44209,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184944</BitOffs>
+            <BitOffs>634302224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_SBCS_TABLE</Name>
@@ -46554,22 +44224,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
-            <Comment> TRUE = Enable DCF77 telegram plausibility check (two telegrams are checked), FALSE = Disable check </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184976</BitOffs>
+            <BitOffs>634302240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_FIELD_SEP</Name>
@@ -46584,202 +44239,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184984</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
-            <Comment> Default DCF77 short/long pulse split time value. Bit == 0 =&gt; pulse &lt; 140ms, Bit == 1 =&gt; pulse &gt;= 140ms </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>140</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
-            <Comment> Max. System Service local adapter name length (256 + 4 inkl. \0) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>259</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
-            <Comment> Max. System Service local adapter descirpion length (128 + 4 inkl. \0) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>131</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
-            <Comment> Max. System Service local adapter physical address length (bytes[0..7]) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>7</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
-            <Comment> IPHELPERAPI index group </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>701</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
-            <Comment> IPHOSTNAME index group </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>702</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
-            <Comment> IPHELPERAPI index offset </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
-            <Comment> IPHELPERAPI index offset </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
-            <Comment> Max. number of local network adapters </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>5</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
-            <Comment> System Service route function: Add route </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>801</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
-            <Comment> System Service route function: Delete route  </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>802</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
-            <Comment> System Service route function: Enumerater route </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>803</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_REMOTE_PCS</Name>
-            <Comment> Max. number of TwinCAT remote systems/PC's </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>99</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246848</BitOffs>
+            <BitOffs>634302256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_NAME_LEN</Name>
@@ -46794,7 +44254,202 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246864</BitOffs>
+            <BitOffs>634302264</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
+            <Comment> Default DCF77 short/long pulse split time value. Bit == 0 =&gt; pulse &lt; 140ms, Bit == 1 =&gt; pulse &gt;= 140ms </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>140</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634302272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
+            <Comment> Max. System Service local adapter name length (256 + 4 inkl. \0) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>259</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634363776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
+            <Comment> Max. System Service local adapter descirpion length (128 + 4 inkl. \0) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>131</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634363808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
+            <Comment> Max. System Service local adapter physical address length (bytes[0..7]) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>7</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634363840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
+            <Comment> IPHELPERAPI index group </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>701</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634363872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
+            <Comment> IPHOSTNAME index group </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>702</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634363904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
+            <Comment> IPHELPERAPI index offset </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634363936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
+            <Comment> IPHELPERAPI index offset </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634363968</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
+            <Comment> Max. number of local network adapters </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
+            <Comment> System Service route function: Add route </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>801</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
+            <Comment> System Service route function: Delete route  </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>802</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
+            <Comment> System Service route function: Enumerater route </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>803</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_REMOTE_PCS</Name>
+            <Comment> Max. number of TwinCAT remote systems/PC's </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>99</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_ADDR_LEN</Name>
@@ -46809,52 +44464,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
-            <Comment> TwinCAT route flag: Temporary </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246880</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
-            <Comment> TwinCAT route flag: Hostname instead OF IP address </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
-            <Comment> TwinCAT route flag: No override </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4246944</BitOffs>
+            <BitOffs>634364144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MIN_ROUTE_TRANSPORT</Name>
@@ -46869,7 +44479,52 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246976</BitOffs>
+            <BitOffs>634364152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
+            <Comment> TwinCAT route flag: Temporary </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
+            <Comment> TwinCAT route flag: Hostname instead OF IP address </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
+            <Comment> TwinCAT route flag: No override </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_TRANSPORT</Name>
@@ -46884,7 +44539,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246984</BitOffs>
+            <BitOffs>634364256</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
+            <Comment> CSV separator constant: double-quote (") =&gt; used to enclose special characters like line breaks, double-quotes, commas... </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BYTE</BaseType>
+            <Default>
+              <Value>34</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634364264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_AMSLOGGER</Name>
@@ -46899,7 +44569,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4246992</BitOffs>
+            <BitOffs>634364272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ROUTE_ENTRY</Name>
@@ -46933,7 +44603,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4247008</BitOffs>
+            <BitOffs>634364288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FFILEFIND</Name>
@@ -46948,7 +44618,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248192</BitOffs>
+            <BitOffs>634365472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.HKEY_MAX_BINARY_DATA_SIZE</Name>
@@ -46963,7 +44633,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248224</BitOffs>
+            <BitOffs>634365504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IGR_GENERAL</Name>
@@ -46978,7 +44648,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248256</BitOffs>
+            <BitOffs>634365536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IOF_MODE</Name>
@@ -46993,7 +44663,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248288</BitOffs>
+            <BitOffs>634365568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_MAX_ARGS</Name>
@@ -47008,7 +44678,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248320</BitOffs>
+            <BitOffs>634365600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_NAN</Name>
@@ -47023,7 +44693,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248336</BitOffs>
+            <BitOffs>634365616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_INF</Name>
@@ -47038,7 +44708,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248352</BitOffs>
+            <BitOffs>634365632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_DIGITS</Name>
@@ -47053,7 +44723,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248368</BitOffs>
+            <BitOffs>634365648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_PRECISION</Name>
@@ -47068,7 +44738,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248384</BitOffs>
+            <BitOffs>634365664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MIN_PRECISION</Name>
@@ -47083,7 +44753,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248400</BitOffs>
+            <BitOffs>634365680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_NOERROR</Name>
@@ -47098,7 +44768,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248416</BitOffs>
+            <BitOffs>634365696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PERCENTSIGNPOSITION</Name>
@@ -47113,7 +44783,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248448</BitOffs>
+            <BitOffs>634365728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ASTERISKPOSITION</Name>
@@ -47128,7 +44798,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248480</BitOffs>
+            <BitOffs>634365760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHVALUE</Name>
@@ -47143,7 +44813,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248512</BitOffs>
+            <BitOffs>634365792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONVALUE</Name>
@@ -47158,7 +44828,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248544</BitOffs>
+            <BitOffs>634365824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_FLAGPOSITION</Name>
@@ -47173,7 +44843,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248576</BitOffs>
+            <BitOffs>634365856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHPRECISIONVALPOS</Name>
@@ -47188,7 +44858,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248608</BitOffs>
+            <BitOffs>634365888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONDOTPOSITION</Name>
@@ -47203,7 +44873,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248640</BitOffs>
+            <BitOffs>634365920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_TYPEFIELDVALUE</Name>
@@ -47218,7 +44888,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248672</BitOffs>
+            <BitOffs>634365952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ARGTYPEINVALID</Name>
@@ -47233,7 +44903,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248704</BitOffs>
+            <BitOffs>634365984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_UNACCEPTEDPARAMETER</Name>
@@ -47248,7 +44918,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248736</BitOffs>
+            <BitOffs>634366016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INSUFFICIENTARGS</Name>
@@ -47263,7 +44933,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248768</BitOffs>
+            <BitOffs>634366048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_DESTBUFFOVERFLOW</Name>
@@ -47278,7 +44948,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248800</BitOffs>
+            <BitOffs>634366080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INVALIDPOINTERINPUT</Name>
@@ -47293,7 +44963,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248832</BitOffs>
+            <BitOffs>634366112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ARG_VALUE</Name>
@@ -47319,7 +44989,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248864</BitOffs>
+            <BitOffs>634366144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_HEXASC_CODES</Name>
@@ -47468,7 +45138,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4248960</BitOffs>
+            <BitOffs>634366240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_DECASC_CODES</Name>
@@ -47526,7 +45196,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4249216</BitOffs>
+            <BitOffs>634366496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_MONTHDAYS</Name>
@@ -47643,7 +45313,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4254704</BitOffs>
+            <BitOffs>634371984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_YEARSDAY</Name>
@@ -47776,7 +45446,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255088</BitOffs>
+            <BitOffs>634372368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
@@ -47791,7 +45461,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255552</BitOffs>
+            <BitOffs>634372832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC</Name>
@@ -47813,7 +45483,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255584</BitOffs>
+            <BitOffs>634372864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC</Name>
@@ -47835,7 +45505,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255648</BitOffs>
+            <BitOffs>634372928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY</Name>
@@ -47857,7 +45527,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255712</BitOffs>
+            <BitOffs>634372992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN</Name>
@@ -47879,7 +45549,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255776</BitOffs>
+            <BitOffs>634373056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX</Name>
@@ -47901,7 +45571,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255840</BitOffs>
+            <BitOffs>634373120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC64</Name>
@@ -47916,7 +45586,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4255936</BitOffs>
+            <BitOffs>634373184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC64</Name>
@@ -47931,7 +45601,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256000</BitOffs>
+            <BitOffs>634373248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY64</Name>
@@ -47946,7 +45616,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256064</BitOffs>
+            <BitOffs>634373312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN64</Name>
@@ -47961,7 +45631,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256128</BitOffs>
+            <BitOffs>634373376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX64</Name>
@@ -47976,7 +45646,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256192</BitOffs>
+            <BitOffs>634373440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.WEST_EUROPE_TZI</Name>
@@ -48049,7 +45719,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4256256</BitOffs>
+            <BitOffs>634373504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERDAY</Name>
@@ -48064,7 +45734,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4261216</BitOffs>
+            <BitOffs>634378496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERWEEK</Name>
@@ -48079,7 +45749,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4261248</BitOffs>
+            <BitOffs>634378528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_NONE</Name>
@@ -48094,7 +45764,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4267456</BitOffs>
+            <BitOffs>634384736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_LOG</Name>
@@ -48109,7 +45779,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4267488</BitOffs>
+            <BitOffs>634384768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_FILE</Name>
@@ -48124,7 +45794,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4267520</BitOffs>
+            <BitOffs>634384800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_VISU</Name>
@@ -48139,22 +45809,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4267552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
-            <Comment> CSV separator constant: double-quote (") =&gt; used to enclose special characters like line breaks, double-quotes, commas... </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BYTE</BaseType>
-            <Default>
-              <Value>34</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4384720</BitOffs>
+            <BitOffs>634384832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_CR</Name>
@@ -48169,7 +45824,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4384728</BitOffs>
+            <BitOffs>634502000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_LF</Name>
@@ -48184,7 +45839,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4384736</BitOffs>
+            <BitOffs>634502008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRUCT</Name>
@@ -48241,7 +45896,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4386464</BitOffs>
+            <BitOffs>634503744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRING</Name>
@@ -48255,7 +45910,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4386592</BitOffs>
+            <BitOffs>634503872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_REGSTRING</Name>
@@ -48269,25 +45924,195 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4386888</BitOffs>
+            <BitOffs>634504168</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
-            <Comment> TcUnit logs complete test results. These include:
-         - Number of test suites
-         - Number of tests
-         - Number of successful tests
-         - Number of failed tests
-         - Any eventual failed assertion (with the expected &amp; actual value plus an user defined message)
-       These are all printed to the ADS logger (Visual Studio error list) marked with ERROR criticality
-
-       On top of this TcUnit also reports some statistics/extended information with HINT/INFO criticality.
-       These statistics are more detailed results of the tests. This information is used when results are
-       being collected by an external software (such as TcUnit-Runner) to do for example Jenkins integration.
-       This extra information however takes time to print, so by setting the following parameter to FALSE
-       it will speed up TcUnit finishing. </Comment>
+            <Name>MOTION_GVL.fbPmpsFileReader</Name>
+            <Comment> Global file reader instance, used in fbStandardPMPSDB</Comment>
+            <BitSize>928512</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">FB_JsonFileToJsonDoc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634504576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
+            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
+            <BitSize>90624</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)DB
+        io: io
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635433088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.nMaxStateMotorCount</Name>
+            <Comment> Debug, records the highest number of motors used in an ND states block in the PLC. Can be used to limit MotionConstants.MAX_STATE_MOTORS to save on memory usage and PV count.</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635523712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MOTION_GVL.nMaxStates</Name>
+            <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635523728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MotionConstants.MAX_STATE_MOTORS</Name>
+            <Comment>
+    Arbitary cap on multidimensional states to simplify statements for the compiler.
+    This is reconfigurable at the project level and should be set to the highest number of motors used in a states block.
+    If you are not sure how many motors are used per state block, check MOTION_GVL.nMaxStateMotorCount
+    </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>3</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635523744</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GeneralConstants.MAX_STATES</Name>
+            <Comment> 16 including "Unknown" is the max for an EPICS MBBI/MBBO
+ This is the max number of user-defined states (OUT, TARGET1, YAG...)
+ You can make this smaller if you want to use less memory in your program in exchange for limiting your max state count
+ You can make this larger if you want to use states-based FBs sized beyond the EPICS enum limit</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>15</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635523760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_lcls_twincat_motion</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>4</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>2</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>4.2.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635523776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>DefaultGlobals.stSys</Name>
+            <Comment>Included for you</Comment>
+            <BitSize>40</BitSize>
+            <BaseType Namespace="LCLS_General">ST_System</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524064</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.bTrickleTripped</Name>
+            <Comment> Global trickle trip flag</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)LCLSGeneral:GlobalLogTrickleTrip
+        io: i
+        field: DESC Tripped by overall log count
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.iLogPort</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>54321</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)LCLSGeneral:LogPort
+        io: io
+        field: DESC The log host UDP port
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nLocalTripThreshold</Name>
+            <Comment> Minimum time between log messages</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
             <Default>
               <Value>1</Value>
             </Default>
@@ -48296,7 +46121,87 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387224</BitOffs>
+            <BitOffs>635524128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>DefaultGlobals.fTimeStamp</Name>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.cLogHost</Name>
+            <Comment>
+    Using the IP address directly avoids DNS configuration issues.
+    While we may want to address this in the future, for now the static IP
+    will suffice:
+
+    $ nslookup ctl-logsrv01
+    Name:   ctl-logsrv01.pcdsn
+    Address: 172.21.32.36
+    </Comment>
+            <BitSize>128</BitSize>
+            <BaseType>STRING(15)</BaseType>
+            <Default>
+              <String>172.21.32.36</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)LCLSGeneral:LogHost
+        io: io
+        field: DESC The log host IP address
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524224</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.sIpTidbit</Name>
+            <BitSize>56</BitSize>
+            <BaseType>STRING(6)</BaseType>
+            <Default>
+              <String>172.21</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bInit</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <BitOffs>635524408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
+            <Comment> Trip if `nLocalTripThreshold` exceeded `nMinTimeViolationAcceptable` times</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>5</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_SEVERITY</Name>
@@ -48310,7 +46215,189 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387312</BitOffs>
+            <BitOffs>635524432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
+            <Comment> Default trickle trip, activated by global threshold</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTrickleTripTime</Name>
+            <Comment> Default time for log-handler to recognize a trickle overload condition, many log-message FB occasionally creating a message</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nTripResetPeriod</Name>
+            <Comment> Default time for CB auto-reset</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
+            <Default>
+              <Value>600000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.sPlcHostname</Name>
+            <BitSize>648</BitSize>
+            <BaseType>STRING(80)</BaseType>
+            <Default>
+              <String>unknown</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635524544</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.bVirtualAxesActive</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: TMO:MRCO:SP:bVirtualAxesActive
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>635525192</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
+            <Comment> Maximum # of attenuators in the PMPS</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635525200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
+            <Comment> Ref: https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/TcPlcLibTcpIp_FB_SocketUdpSendTo.htm
+        TODO: Activate the "Replace constants" option in the
+        TwinCAT PLC Control-&gt;"Project-&gt;Options...-&gt;Build" dialog window.
+    </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>10000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>analysis</Name>
+                <Value>-33</Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635525216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.fbRootLogger</Name>
+            <Comment>Instantiated here to be used everywhere</Comment>
+            <BitSize>81984</BitSize>
+            <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635525248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.nGlobAccEvents</Name>
+            <Comment> Global log message count</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)LCLSGeneral:LogMessageCount
+        io: i
+        field: DESC Total log messages on the last cycle
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635607232</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_Tc2_EtherCAT</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>3</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>21</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>3.3.21.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635607264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_IoFunctions</Name>
@@ -48350,7 +46437,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387328</BitOffs>
+            <BitOffs>635607552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ModbusSrv</Name>
@@ -48386,7 +46473,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387616</BitOffs>
+            <BitOffs>635607840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_SerialCom</Name>
@@ -48426,7 +46513,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4387904</BitOffs>
+            <BitOffs>635608128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_CLASS</Name>
@@ -48483,7 +46570,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388192</BitOffs>
+            <BitOffs>635608416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_ID</Name>
@@ -48497,7 +46584,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388320</BitOffs>
+            <BitOffs>635608544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.SUCCESS_EVENT</Name>
@@ -48562,7 +46649,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388352</BitOffs>
+            <BitOffs>635608576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.nLangId_OnlineMonitoring</Name>
@@ -48577,7 +46664,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388544</BitOffs>
+            <BitOffs>635608768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>ParameterList.cSourceNameSize</Name>
@@ -48600,7 +46687,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388576</BitOffs>
+            <BitOffs>635608800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_EventLogger</Name>
@@ -48640,7 +46727,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388608</BitOffs>
+            <BitOffs>635608832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_INTERNAL.UNINITIALIZED_CLASS_GUID</Name>
@@ -48698,7 +46785,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4388896</BitOffs>
+            <BitOffs>635609120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -48712,7 +46799,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389024</BitOffs>
+            <BitOffs>635609248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_JsonXml</Name>
@@ -48752,474 +46839,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4389056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>1000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4389344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4389360</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>1000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4389376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
-            <Comment> Enable (TRUE) or disable (FALSE) publishing of the xUnit Xml report </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4389392</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
-            <Comment> Indication of whether the last instantiated test suite has an assert instance created </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4389400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
-            <Comment> Default reserved PLC memory buffer used for composition of the xUnit xml file (64 kb default) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>65535</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4389408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
-            <Comment> Default path and filename for the xunit testresults e.g.: for use with jenkins </Comment>
-            <BitSize>2048</BitSize>
-            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
-            <Default>
-              <String>C:\tcunit_xunit_testresults.xml</String>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4389440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
-            <Comment> This is the maximum number of ADS-messages that can be stored for reporting at the same time.
-       Having a size of 2000 means that it's possible to report up to ~400 test cases in one single
-       PLC cycle. Each entry consumes around 500 bytes, so with an example of a ring buffer size of
-       2000 it means that TcUnit will consume around 1 MB of router memory. </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>2000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4391488</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
-            <Comment> Whether or not the current test being called has finished running </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4391504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
-            <Comment> This is a flag that indicates that the current test should be ignored, and
-       thus that all assertions under it should be ignored as well. A test can be ignored either
-       because the user has requested so, or because the test is a duplicate name </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4391512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
-            <Comment> Time delay between a test suite is finished and the execution of the next test suite starts
-       if using RUN_IN_SEQUENCE() </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4391520</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.TcUnitRunner</Name>
-            <BitSize>621827200</BitSize>
-            <BaseType Namespace="LCLS_General.TcUnit">FB_TcUnitRunner</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4391552</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
-            <Comment> Pointer to current test suite being called </Comment>
-            <BitSize>32</BitSize>
-            <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>626218752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
-            <Comment> Current name of test being called </Comment>
-            <BitSize>2048</BitSize>
-            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>626218784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
-            <Comment> The assert function block instance should be 1:1 mapped to
-       the test suite instance path. </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>626220832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MOTION_GVL.nMaxStateMotorCount</Name>
-            <Comment> Debug, records the highest number of motors used in an ND states block in the PLC. Can be used to limit MotionConstants.MAX_STATE_MOTORS to save on memory usage and PV count.</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>626220848</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.TestSuiteAddresses</Name>
-            <BitSize>32000</BitSize>
-            <BaseType PointerTo="1" Namespace="LCLS_General.TcUnit">FB_TestSuite</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>1000</Elements>
-            </ArrayInfo>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>626220864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
-            <Comment> If the user is utilizing the TEST_ORDERED(), we need to keep track of which ordered test is currently running.
-       We do this by defining an array, in where we can see which current TEST_ORDERED() is the one to be handled right now.
-       The below array is only used for TEST_ORDERED()-tests.  </Comment>
-            <BitSize>16000</BitSize>
-            <BaseType>UINT</BaseType>
-            <ArrayInfo>
-              <LBound>1</LBound>
-              <Elements>1000</Elements>
-            </ArrayInfo>
-            <Properties>
-              <Property>
-                <Name>LowerBorder</Name>
-                <Value>1</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>100</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>626252864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.AdsMessageQueue</Name>
-            <Comment> Buffered ADS message queue for output to the error list </Comment>
-            <BitSize>8320864</BitSize>
-            <BaseType Namespace="LCLS_General.TcUnit">FB_AdsLogStringMessageFifoQueue</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>626268864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_TcUnit</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>2</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>1.2.0.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634589728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.PI</Name>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>3.14159265358979</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634590016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_math</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>1.0.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634590080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MOTION_GVL.nMaxStates</Name>
-            <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634590368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MotionConstants.MAX_STATE_MOTORS</Name>
-            <Comment>
-    Arbitary cap on multidimensional states to simplify statements for the compiler.
-    This is reconfigurable at the project level and should be set to the highest number of motors used in a states block.
-    If you are not sure how many motors are used per state block, check MOTION_GVL.nMaxStateMotorCount
-    </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>3</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634590384</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MOTION_GVL.fbPmpsFileReader</Name>
-            <Comment> Global file reader instance, used in fbStandardPMPSDB</Comment>
-            <BitSize>928512</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.PMPS">FB_JsonFileToJsonDoc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634590400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>MOTION_GVL.fbStandardPMPSDB</Name>
-            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
-            <BitSize>90624</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)DB
-        io: io
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635518912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_motion</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>0.0.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635609536</BitOffs>
+            <BitOffs>635609280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
@@ -49239,7 +46859,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635609824</BitOffs>
+            <BitOffs>635609568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
@@ -49259,7 +46879,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635611584</BitOffs>
+            <BitOffs>635611328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
@@ -49284,7 +46904,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635613344</BitOffs>
+            <BitOffs>635613088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -49296,7 +46916,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614368</BitOffs>
+            <BitOffs>635614112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
@@ -49311,7 +46931,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614400</BitOffs>
+            <BitOffs>635614144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
@@ -49325,7 +46945,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614432</BitOffs>
+            <BitOffs>635614176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -49339,7 +46959,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614464</BitOffs>
+            <BitOffs>635614208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -49353,7 +46973,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614528</BitOffs>
+            <BitOffs>635614272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -49368,22 +46988,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
-            <Comment> Maximum # of attenuators in the PMPS</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635614624</BitOffs>
+            <BitOffs>635614336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -49397,68 +47002,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614640</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stAttenuators</Name>
-            <BitSize>64</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_PMPS_Attenuator</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.xAttOK</Name>
-                <Value>1</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635614656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstFullBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)FullBeamCnst
-        io: i
-        archive: 1Hz monitor
-        field: DESC Full beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635614720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cst0RateBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)0RateBeamCnst
-        io: i
-        archive: 1Hz monitor
-        field: DESC 0-rate beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635616480</BitOffs>
+            <BitOffs>635614368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -49483,7 +47027,68 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635618240</BitOffs>
+            <BitOffs>635614384</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stAttenuators</Name>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_PMPS_Attenuator</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.xAttOK</Name>
+                <Value>1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635614400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+        io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635614464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cst0RateBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="lcls_twincat_motion.PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)0RateBeamCnst
+        io: i
+        archive: 1Hz monitor
+        field: DESC 0-rate beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635616224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -49498,7 +47103,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635618256</BitOffs>
+            <BitOffs>635617984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_cBoundaries</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>31</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635618000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -49517,36 +47136,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635618272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.g_cBoundaries</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>31</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635619296</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
-            <Comment> Max fast faults for an FFO</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>50</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635619312</BitOffs>
+            <BitOffs>635618016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -49573,7 +47163,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635619328</BitOffs>
+            <BitOffs>635619040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -49728,7 +47318,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635619360</BitOffs>
+            <BitOffs>635619072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -49883,7 +47473,33 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635620384</BitOffs>
+            <BitOffs>635620096</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
+            <Comment> Max fast faults for an FFO</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>50</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635621120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>FB_DynMem_Manager.nInstanceCreations</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarStatic</Name>
+              </Property>
+            </Properties>
+            <BitOffs>635621136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -49898,7 +47514,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635621408</BitOffs>
+            <BitOffs>635621152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -49913,7 +47529,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635621440</BitOffs>
+            <BitOffs>635621184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -49924,7 +47540,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635621472</BitOffs>
+            <BitOffs>635621216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -49964,7 +47580,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635621728</BitOffs>
+            <BitOffs>635621760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -49975,7 +47591,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635622016</BitOffs>
+            <BitOffs>635622048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -49989,7 +47605,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635628992</BitOffs>
+            <BitOffs>635629056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -50003,7 +47619,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635629056</BitOffs>
+            <BitOffs>635629120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -50039,7 +47655,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635629120</BitOffs>
+            <BitOffs>635629184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_IPCDiag</Name>
@@ -50079,7 +47695,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635629408</BitOffs>
+            <BitOffs>635629472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_DynamicMemory</Name>
@@ -50119,46 +47735,12 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635630720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>FB_DynMem_Manager.nInstanceCreations</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarStatic</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635672192</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bInit</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <BitOffs>635672208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.bVirtualAxesActive</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: TMO:MRCO:SP:bVirtualAxesActive
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>635672216</BitOffs>
+            <BitOffs>635630784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
             <Comment> Gas Nozzle X</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50173,12 +47755,12 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635682496</BitOffs>
+            <BitOffs>635680768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
             <Comment> Gas Nozzle Y</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50193,12 +47775,12 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635708672</BitOffs>
+            <BitOffs>635706752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
             <Comment> Gas Nozzle Z</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50213,12 +47795,12 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635734848</BitOffs>
+            <BitOffs>635732736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
             <Comment> Sample Paddle X Stage Coordinates</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50233,12 +47815,12 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635761024</BitOffs>
+            <BitOffs>635758720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
             <Comment> Sample Paddle Y Stage Coordinates</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50253,12 +47835,12 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635787200</BitOffs>
+            <BitOffs>635784704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
             <Comment> Sample Paddle Z Stage Coordinates</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50273,12 +47855,12 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635813376</BitOffs>
+            <BitOffs>635810688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M7</Name>
             <Comment> Sample Paddle X Beam Coordinates (Virtual Axis)</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50288,12 +47870,12 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635839552</BitOffs>
+            <BitOffs>635836672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M8</Name>
             <Comment> Sample Paddle Y Beam Coordinates (Virtual Axis)</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50303,12 +47885,12 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635865728</BitOffs>
+            <BitOffs>635862656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M9</Name>
             <Comment> Sample Paddle Z Beam Coordinates (Virtual Axis)</Comment>
-            <BitSize>26176</BitSize>
+            <BitSize>25984</BitSize>
             <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
             <Properties>
               <Property>
@@ -50318,65 +47900,65 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>635891904</BitOffs>
+            <BitOffs>635888640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM1</Name>
             <Comment> MRCO Axes</Comment>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635918080</BitOffs>
+            <BitOffs>635914624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM2</Name>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636226496</BitOffs>
+            <BitOffs>636214016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM3</Name>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636534912</BitOffs>
+            <BitOffs>636513408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM4</Name>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636843328</BitOffs>
+            <BitOffs>636812800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM5</Name>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>637151744</BitOffs>
+            <BitOffs>637112192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM6</Name>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>637460160</BitOffs>
+            <BitOffs>637411584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM7</Name>
             <Comment> Virtual</Comment>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>637768576</BitOffs>
+            <BitOffs>637710976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM8</Name>
             <Comment> Virtual</Comment>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>638076992</BitOffs>
+            <BitOffs>638010368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStageM9</Name>
             <Comment> Virtual</Comment>
-            <BitSize>308416</BitSize>
+            <BitSize>299392</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>638385408</BitOffs>
+            <BitOffs>638309760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nVirtualEncoderUnitConversion</Name>
@@ -50386,13 +47968,13 @@ External Setpoint Generation:
             <Default>
               <Value>1000000</Value>
             </Default>
-            <BitOffs>638693824</BitOffs>
+            <BitOffs>638609152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.bBaseToNew</Name>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
-            <BitOffs>638693984</BitOffs>
+            <BitOffs>638609312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bLittleEndian</Name>
@@ -50407,7 +47989,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638694000</BitOffs>
+            <BitOffs>638609328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
@@ -50422,7 +48004,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638694008</BitOffs>
+            <BitOffs>638609336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.stPMotionTransform3D</Name>
@@ -50436,7 +48018,7 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638694016</BitOffs>
+            <BitOffs>638609344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.stVMotionTransform3D</Name>
@@ -50450,7 +48032,7 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638694976</BitOffs>
+            <BitOffs>638610304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.stAMotionTransform3D</Name>
@@ -50464,49 +48046,49 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638695936</BitOffs>
+            <BitOffs>638611264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fDPosM7</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638696896</BitOffs>
+            <BitOffs>638612224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fDPosM8</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638696960</BitOffs>
+            <BitOffs>638612288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fDPosM9</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
-            <BitOffs>638697024</BitOffs>
+            <BitOffs>638612352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.rtM7Execute</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>638697088</BitOffs>
+            <BitOffs>638612416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.rtM8Execute</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>638697152</BitOffs>
+            <BitOffs>638612480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.rtM9Execute</Name>
             <BitSize>64</BitSize>
             <BaseType Namespace="Tc2_Standard">R_TRIG</BaseType>
-            <BitOffs>638697216</BitOffs>
+            <BitOffs>638612544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionVirtualFrame</Name>
             <BitSize>8000</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">FB_MotionVirtualFrame</BaseType>
-            <BitOffs>638697280</BitOffs>
+            <BaseType>FB_MotionVirtualFrame</BaseType>
+            <BitOffs>638612608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.sOrder</Name>
@@ -50515,7 +48097,7 @@ External Setpoint Generation:
             <Default>
               <String>XYZ</String>
             </Default>
-            <BitOffs>638705280</BitOffs>
+            <BitOffs>638620608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
@@ -50529,7 +48111,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638705928</BitOffs>
+            <BitOffs>638621256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -50544,7 +48126,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638705936</BitOffs>
+            <BitOffs>638621264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -50559,13 +48141,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638705952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbEPSSamplePaddleGasNeedle</Name>
-            <BitSize>448</BitSize>
-            <BaseType>FB_EPSSamplePaddleGasNeedle</BaseType>
-            <BitOffs>638705984</BitOffs>
+            <BitOffs>638621280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.aDeg</Name>
@@ -50588,7 +48164,7 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638706432</BitOffs>
+            <BitOffs>638621312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.bDeg</Name>
@@ -50611,7 +48187,7 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638706496</BitOffs>
+            <BitOffs>638621376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.gDeg</Name>
@@ -50634,7 +48210,7 @@ External Setpoint Generation:
     </Value>
               </Property>
             </Properties>
-            <BitOffs>638706560</BitOffs>
+            <BitOffs>638621440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -50664,7 +48240,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638707936</BitOffs>
+            <BitOffs>638622816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -50694,7 +48270,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638708000</BitOffs>
+            <BitOffs>638622880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -50708,7 +48284,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638708064</BitOffs>
+            <BitOffs>638622944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -50722,7 +48298,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638708096</BitOffs>
+            <BitOffs>638622976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -50736,7 +48312,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638708128</BitOffs>
+            <BitOffs>638623008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -50750,7 +48326,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638710176</BitOffs>
+            <BitOffs>638625056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -50768,7 +48344,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638710208</BitOffs>
+            <BitOffs>638625088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -50782,7 +48358,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638711232</BitOffs>
+            <BitOffs>638626112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -50803,7 +48379,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638711264</BitOffs>
+            <BitOffs>638626144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -50872,7 +48448,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638727456</BitOffs>
+            <BitOffs>638642336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -50941,7 +48517,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638727584</BitOffs>
+            <BitOffs>638642464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -51010,7 +48586,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638727712</BitOffs>
+            <BitOffs>638642592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -51079,7 +48655,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638727968</BitOffs>
+            <BitOffs>638642848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -51148,7 +48724,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638728224</BitOffs>
+            <BitOffs>638643104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -51217,7 +48793,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638728352</BitOffs>
+            <BitOffs>638643232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -51240,14 +48816,60 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>638758816</BitOffs>
+            <BitOffs>638673696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_lcls_twincat_math</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>1.0.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>641695616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbEPSSamplePaddleGasNeedle</Name>
+            <BitSize>448</BitSize>
+            <BaseType>FB_EPSSamplePaddleGasNeedle</BaseType>
+            <BitOffs>641696576</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>80543744</ByteSize>
+          <ByteSize>81002496</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -51330,15 +48952,15 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2025-07-31T15:50:36</Value>
+          <Value>2025-08-28T14:22:21</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>634880</Value>
+          <Value>618496</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>79409152</Value>
+          <Value>79396864</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
…. Will need to delete it after the next library release occurs. Tightened up the target position window on Sample paddle X,y,z since their errors accumulate when being coordinated to make virtual motion.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The accuracy and repeatability of the virtual axes was not very good.
- Realized that the error of the virtual axes is related to the combined error of the 3 moving axes.
- To combat this, reduced the target position window of the 3 real axes so that when their errors combine for a virtual axis motion the accumulated error is acceptable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested by running the virtual z axis forward and back a bunch of times and slowly tightening the target position window until the accumulated error on the virtual z axis was acceptable.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
